### PR TITLE
Fix: Add video download button in modal player (#31)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,7 @@ import { Layout, ContentContainer, PageHeader } from './components/Layout/Layout
 import { YouTubeDownload } from './components/YouTubeDownload';
 import { DownloadQueue } from './components/DownloadQueue';
 import { useVideos } from './hooks/useVideos';
+import { getVideoStreamUrl } from './services/api';
 
 // Create Query Client outside component to avoid recreation on renders
 const queryClient = new QueryClient({
@@ -79,13 +80,24 @@ function App() {
             onClick={handleClosePlayer} 
           />
           <div className="relative bg-black rounded-lg overflow-hidden max-w-4xl w-full mx-4">
-            <button 
-              className="absolute top-4 right-4 z-10 text-white hover:text-gray-300 text-2xl font-bold"
-              onClick={handleClosePlayer}
-              aria-label="Close video player"
-            >
-              ✕
-            </button>
+            <div className="absolute top-4 right-4 z-10 flex gap-2">
+              <a
+                href={getVideoStreamUrl(selectedVideo.file.name)}
+                download={selectedVideo.file.name}
+                className="text-white hover:text-gray-300 text-xl p-2"
+                aria-label="Download video"
+                title="Download video"
+              >
+                ↓
+              </a>
+              <button 
+                className="text-white hover:text-gray-300 text-2xl font-bold"
+                onClick={handleClosePlayer}
+                aria-label="Close video player"
+              >
+                ✕
+              </button>
+            </div>
             <VideoPlayer
               video={selectedVideo}
               controls={true}


### PR DESCRIPTION
## Summary

Users want to download videos directly from the modal video player dialog. Currently, videos can only be streamed/played in the browser. The feature request asks for a download button in the modal to allow downloading videos via HTTP to local devices.

## Root Cause

This is an enhancement, not a bug. The video streaming infrastructure already exists with backend streaming endpoint and frontend getVideoStreamUrl() function. The enhancement simply requires exposing this download functionality more prominently via a button in the modal UI.

## Changes

| File | Change |
|------|--------|
| `frontend/src/App.tsx` | Add download button (↓) next to close button in modal header |
| `frontend/src/App.tsx` | Import getVideoStreamUrl from api service |

## Testing

- [x] Type check passes
- [x] Unit tests pass (110/110)
- [x] Lint passes
- [x] Build validation passes

## Validation

```bash
# Run validation commands
cd frontend && npm run type-check && npm test && npm run lint
```

## Issue

Fixes #31

---

<details>
<summary>📋 Implementation Details</summary>

### Implementation followed artifact:

`.claude/PRPs/issues/issue-31.md`

### Deviations from plan:

None - implementation followed artifact exactly

</details>

---

_Automated implementation from investigation artifact_