### PR TITLE
fix(frontend): use same-origin API base for LAN clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,20 @@ make docker
 docker-compose up -d
 ```
 
+
+### Network Access Configuration
+
+By default, the frontend now calls the backend via a **same-origin relative path** (`/api`).
+This allows other devices on your LAN to work when only frontend port `5183` is exposed and API requests are reverse-proxied.
+
+Optional override:
+
+```bash
+VITE_API_BASE_URL=http://<backend-host>:3010/api
+```
+
+Set `VITE_API_BASE_URL` only when you intentionally want the browser to call a specific backend origin directly.
+
 ## Development Commands
 
 ```bash

--- a/frontend/src/__tests__/api.test.ts
+++ b/frontend/src/__tests__/api.test.ts
@@ -46,7 +46,7 @@ describe('API Service', () => {
       const result = await getVideos();
 
       expect(result).toEqual(mockResponse.data);
-      expect(mockFetch).toHaveBeenCalledWith('http://localhost:3010/api/videos');
+      expect(mockFetch).toHaveBeenCalledWith('/api/videos');
     });
 
     test('should throw ApiError on API failure', async () => {
@@ -96,7 +96,7 @@ describe('API Service', () => {
       const result = await getVideoById('test-video-1');
 
       expect(result).toEqual(mockVideo);
-      expect(mockFetch).toHaveBeenCalledWith('http://localhost:3010/api/videos/test-video-1');
+      expect(mockFetch).toHaveBeenCalledWith('/api/videos/test-video-1');
     });
 
     test('should properly encode video ID in URL', async () => {
@@ -107,19 +107,19 @@ describe('API Service', () => {
 
       await getVideoById('video with spaces');
 
-      expect(mockFetch).toHaveBeenCalledWith('http://localhost:3010/api/videos/video%20with%20spaces');
+      expect(mockFetch).toHaveBeenCalledWith('/api/videos/video%20with%20spaces');
     });
   });
 
   describe('getVideoStreamUrl', () => {
     test('should return correct streaming URL', () => {
       const url = getVideoStreamUrl('test-video.mp4');
-      expect(url).toBe('http://localhost:3010/api/stream/test-video.mp4');
+      expect(url).toBe('/api/stream/test-video.mp4');
     });
 
     test('should properly encode filename', () => {
       const url = getVideoStreamUrl('video with spaces.mp4');
-      expect(url).toBe('http://localhost:3010/api/stream/video%20with%20spaces.mp4');
+      expect(url).toBe('/api/stream/video%20with%20spaces.mp4');
     });
   });
 
@@ -133,7 +133,7 @@ describe('API Service', () => {
       };
 
       const url = getVideoThumbnailUrl(video);
-      expect(url).toBe('http://localhost:3010/api/thumbnails/thumb.jpg');
+      expect(url).toBe('/api/thumbnails/thumb.jpg');
     });
 
     test('should return null when no thumbnail', () => {

--- a/frontend/src/__tests__/youtube.test.ts
+++ b/frontend/src/__tests__/youtube.test.ts
@@ -59,7 +59,7 @@ describe('YouTube Service', () => {
 
       expect(result).toEqual(mockResponse.data);
       expect(mockFetch).toHaveBeenCalledWith(
-        'http://localhost:3010/api/youtube/download',
+        '/api/youtube/download',
         {
           method: 'POST',
           headers: {
@@ -135,7 +135,7 @@ describe('YouTube Service', () => {
       const result = await getDownloadQueue();
 
       expect(result).toEqual(mockQueueStatus);
-      expect(mockFetch).toHaveBeenCalledWith('http://localhost:3010/api/youtube/queue', {
+      expect(mockFetch).toHaveBeenCalledWith('/api/youtube/queue', {
         headers: {
           'Content-Type': 'application/json',
         },
@@ -199,7 +199,7 @@ describe('YouTube Service', () => {
 
       expect(result).toEqual({ message: 'Download cancelled successfully', queueItemId: downloadId });
       expect(mockFetch).toHaveBeenCalledWith(
-        `http://localhost:3010/api/youtube/download/${downloadId}`,
+        `/api/youtube/download/${downloadId}`,
         {
           method: 'DELETE',
           headers: {

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,7 +1,9 @@
 import { Video, VideoScanResult, ApiResponse } from '../types';
 
-// Backend API base URL (from docker-compose configuration)
-const API_BASE_URL = 'http://localhost:3010/api';
+const configuredApiBaseUrl = import.meta.env.VITE_API_BASE_URL?.trim();
+
+// Use same-origin API by default so remote clients only need frontend port access.
+export const API_BASE_URL = (configuredApiBaseUrl || '/api').replace(/\/$/, '');
 
 /**
  * Custom error class for API errors

--- a/frontend/src/services/youtube.ts
+++ b/frontend/src/services/youtube.ts
@@ -7,10 +7,7 @@ import {
 } from '../types/youtube';
 
 // Import base API utilities
-import { ApiError } from './api';
-
-// Backend API base URL (consistent with main API service)
-const API_BASE_URL = 'http://localhost:3010/api';
+import { ApiError, API_BASE_URL } from './api';
 
 /**
  * Generic fetch wrapper for YouTube API calls with error handling


### PR DESCRIPTION
### Motivation

- Browsers on other LAN devices were failing API calls because the frontend hardcoded `http://localhost:3010/api`, causing the browser to target the device's own localhost instead of the backend host.
- The intent is to make the frontend usable from other devices when only the frontend port (`5183`) is exposed and the API is reverse-proxied behind the frontend origin.
- Provide an opt-in override for environments that need a specific backend origin via `VITE_API_BASE_URL`.

### Description

- Changed frontend API base resolution in `frontend/src/services/api.ts` to export `API_BASE_URL` defaulting to same-origin `'/api'` with an optional override from `VITE_API_BASE_URL` and normalized trailing slashes. 
- Reused the shared `API_BASE_URL` in `frontend/src/services/youtube.ts` instead of duplicating a hardcoded backend URL. 
- Updated unit tests in `frontend/src/__tests__/api.test.ts` and `frontend/src/__tests__/youtube.test.ts` to assert relative `/api` endpoints. 
- Documented the LAN/network behavior and the `VITE_API_BASE_URL` override in `README.md`.

### Testing

- Ran targeted frontend tests with `timeout 120s npm run test --workspace=frontend -- src/__tests__/api.test.ts src/__tests__/youtube.test.ts` which completed successfully and the test runner reported: `Test Files 10 passed (10)` and `Tests 110 passed (110)` (verified at `2026-03-09T17:48:25+00:00`).
- Ran lint with `npm run lint --workspace=frontend` which exited successfully with no reported lint errors. 
- All updated tests asserting the new same-origin endpoints passed, confirming the change did not break existing API call logic.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af06780e888332ae3c4bfc3b0b4744)