### PR TITLE
Chore: Increase continuous issue resolution frequency to hourly

### DIFF
--- a/.made/workflows.yml
+++ b/.made/workflows.yml
@@ -2,7 +2,7 @@ workflows:
 - id: wf_mmozh3te_a0828
   name: Continuous Issue Resolution
   enabled: true
-  schedule: 0 */2 * * *
+  schedule: 0 * * * *
   steps:
   - type: agent
     agent: build


### PR DESCRIPTION
## Problem
The current MADE workflow for continuous issue resolution runs every 2 hours, which may delay automated issue detection and resolution. More frequent monitoring could provide faster response times to issues.

## Solution
Updated the workflow schedule from "0 */2 * * *" (every 2 hours) to "0 * * * *" (every hour) to enable more proactive issue resolution and faster feedback loops.

## Changes
- Modified `.made/workflows.yml` to change the schedule cron expression
- Maintained existing workflow configuration and structure
- No breaking changes to workflow functionality

## Testing
- All tests passed during commit (192 tests total)
- Pre-commit validation completed successfully (linting, type checking, build)
- Workflow configuration validated with proper YAML syntax

## Example Output
```yaml
workflows:
- id: wf_mmozh3te_a0828
  name: Continuous Issue Resolution
  enabled: true
  schedule: 0 * * * *  # Changed from: 0 */2 * * *
  steps:
  - type: agent
    agent: build
```

## Notes
This change increases the frequency of automated issue resolution from every 2 hours to hourly. The workflow will now trigger 24 times per day instead of 12 times, providing more responsive automated maintenance. No impact on existing functionality or dependencies.