### PR TITLE
Fix: document video storage directory configuration (#45)

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,45 @@ sofathek/
 └── README.md         # This file
 ```
 
+## Video Storage Setup
+
+### Development
+
+The application stores videos in `backend/data/videos` by default. Create the directory:
+
+```bash
+mkdir -p backend/data/videos
+```
+
+To customize the video directory, set the `VIDEOS_PATH` environment variable:
+
+```bash
+# Linux/macOS
+export VIDEOS_PATH=/custom/path/to/videos
+
+# Windows (PowerShell)
+$env:VIDEOS_PATH = "C:\custom\path\to\videos"
+```
+
+### Docker
+
+When running with Docker Compose, videos are stored in a named volume:
+
+```bash
+# Check videos volume location
+docker volume inspect sofathek_videos
+
+# Backup videos
+docker run --rm -v sofathek_videos:/data -v $(pwd)/backup:/backup alpine tar czf /backup/videos.tar.gz -C /data .
+```
+
+### Environment Variables
+
+| Variable     | Default                    | Description                    |
+|--------------|----------------------------|--------------------------------|
+| `VIDEOS_PATH` | `backend/data/videos`      | Path to video storage directory|
+| `VIDEOS_DIR`  | (falls back to VIDEOS_PATH)| Alternate env var for videos  |
+
 ## Requirements
 
 - **Node.js 18+** (for development)

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -116,6 +116,32 @@ MAX_DOWNLOAD_SIZE=2147483648  # 2GB in bytes
 LOG_LEVEL=info
 ```
 
+### Video Storage Configuration
+
+The video storage directory can be customized using environment variables:
+
+| Variable     | Default                    | Description                          |
+|--------------|----------------------------|--------------------------------------|
+| `VIDEOS_DIR` | `/opt/sofathek/data/videos`| Production video storage path        |
+| `VIDEOS_PATH`| (development default)      | Alternative env var, takes precedence in dev |
+| `TEMP_DIR`   | `/opt/sofathek/data/temp`   | Temporary download storage            |
+
+**Docker Example:**
+
+```bash
+docker run -d \
+  -e VIDEOS_DIR=/custom/videos \
+  -v /host/videos:/custom/videos:rw \
+  sofathek/backend
+```
+
+**Volume Backup:**
+
+```bash
+# Using named volumes
+docker run --rm -v sofathek_videos:/data -v $(pwd)/backup:/backup alpine tar czf backup/videos.tar.gz -C /data .
+```
+
 ### 3. Deploy Application
 
 ```bash


### PR DESCRIPTION
## Summary

The deployment and development docs did not clearly explain where video files are stored or how to override storage paths. This update documents the default paths, environment variables, and Docker volume behavior.

## Root Cause

The code already handled video storage via `VIDEOS_PATH`/`VIDEOS_DIR`, but the documentation never captured this behavior after PR #30 clarified path handling.

## Changes

| File | Change |
|------|--------|
| `README.md` | Added `Video Storage Setup` section covering default path, env override examples, Docker volume usage, and environment variable table |
| `docs/DEPLOYMENT.md` | Added `Video Storage Configuration` section with production-focused env var table, Docker run example, and volume backup command |

## Testing

- [x] Lint passes (`make lint`)
- [x] Build passes (`make build`)
- [x] Tests pass (`make test` via pre-commit hook)
- [x] Manual doc verification completed (headings, tables, and code blocks render correctly in markdown)

## Validation

```bash
make lint && make build
```

## Issue

Fixes #45

---

<details>
<summary>📋 Implementation Details</summary>

### Implementation followed artifact:
Issue #45 investigation comment (`https://github.com/tbrandenburg/sofathek/issues/45#issuecomment-4019693716`)

### Deviations from plan:
None

</details>

---

_Automated implementation from investigation artifact_