### PR TITLE
Chore: align continuous issue resolution workflow execution order

### DIFF
--- a/.harness/continuous-issue-resolution.sh
+++ b/.harness/continuous-issue-resolution.sh
@@ -2,140 +2,142 @@
 set -euo pipefail
 
 SCRIPT_NAME="continuous-issue-resolution.sh"
+WORKFLOW_NAME="Continuous Issue Resolution"
+WORKFLOW_SLUG="continuous-issue-resolution"
 
-# Argument handling
 DRY_RUN=false
+RUN_STEP_PROMPT=""
 
-case "${1:-}" in
-  "")
-    # No arguments - normal execution
-    ;;
-  "--dry-run")
-    DRY_RUN=true
-    ;;
-  *)
-    printf 'Usage: %s [--dry-run]\n' "$0" >&2
-    printf '  --dry-run    Simulate execution without running commands\n' >&2
-    exit 2
-    ;;
-esac
+usage() {
+  printf 'Usage: %s [--dry-run]\n' "$SCRIPT_NAME" >&2
+}
 
-# Logging setup with fallback
-LOG_DIR=""
-if [[ -w /var/log ]]; then
-  LOG_DIR="/var/log"
+if [[ $# -eq 0 ]]; then
+  :
+elif [[ $# -eq 1 ]]; then
+  case "$1" in
+    --dry-run)
+      DRY_RUN=true
+      ;;
+    *)
+      usage
+      exit 2
+      ;;
+  esac
+else
+  usage
+  exit 2
+fi
+
+LOG_FILE=""
+if [[ -d /var/log && -w /var/log ]]; then
+  LOG_FILE="/var/log/${WORKFLOW_SLUG}.log"
 else
   LOG_DIR="/tmp/made-harness-logs"
   mkdir -p "$LOG_DIR"
+  LOG_FILE="${LOG_DIR}/${WORKFLOW_SLUG}.log"
 fi
-LOG_FILE="$LOG_DIR/${SCRIPT_NAME%.sh}.log"
 
 log() {
-  local level="$1"; shift
-  local timestamp message
+  local level="$1"
+  shift
+  local timestamp message line
+
   timestamp="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
-  message="$timestamp [$level] $*"
-  
-  # Always log to stderr
-  printf '%s\n' "$message" >&2
-  
-  # Append to log file if possible (never fail on logging errors)
-  if [[ -w "$LOG_DIR" ]]; then
-    printf '%s\n' "$message" >> "$LOG_FILE" 2>/dev/null || true
+  message="$*"
+  line="${timestamp} [${level}] ${message}"
+
+  printf '%s\n' "$line" >&2 || true
+  if [[ -n "$LOG_FILE" ]]; then
+    printf '%s\n' "$line" >>"$LOG_FILE" 2>/dev/null || true
   fi
 }
 
 need_cmd() {
-  local cmd="$1"
-  if ! command -v "$cmd" >/dev/null 2>&1; then
-    log ERROR "Missing dependency: $cmd"
+  command -v "$1" >/dev/null 2>&1 || {
+    log ERROR "Missing dependency: $1"
     exit 1
-  fi
+  }
 }
 
 run_step() {
-  local desc="$1"; shift
+  local desc="$1"
+  shift
   local cmd=("$@")
-  
+
   if [[ "$DRY_RUN" == true ]]; then
     log INFO "[DRY-RUN] $desc"
     printf '%q ' "${cmd[@]}"
     printf '\n'
+    return 0
+  fi
+
+  log INFO "$desc"
+  if [[ -n "$RUN_STEP_PROMPT" ]]; then
+    printf '%s' "$RUN_STEP_PROMPT" | "${cmd[@]}"
   else
-    log INFO "$desc"
     "${cmd[@]}"
   fi
 }
 
-# Verify dependencies
 need_cmd opencode
 
-log INFO "Starting workflow: Continuous Issue Resolution"
+log INFO "Starting workflow: ${WORKFLOW_NAME}"
 
-# Step 1: Follow the instructions in @.opencode/commands/prp-issue-fix.md for the latest open issue on Github and take its investigation comment as the implementation plan
-STEP1_DESCRIPTION="Follow the instructions in @.opencode/commands/prp-issue-fix.md for the latest open issue on Github and take its investigation comment as the implementation plan"
-STEP1_PROMPT="Follow the instructions in @.opencode/commands/prp-issue-fix.md for the latest open issue on Github and take its investigation comment as the implementation plan"
-
+# Step 1: agent build
+STEP1_DESCRIPTION="If not on main, switch back to main and do a fresh git pull"
+STEP1_PROMPT="If not on main, switch back to main and do a fresh git pull"
 cmd=(opencode run --format json --agent build)
-if [[ "$DRY_RUN" == true ]]; then
-  run_step "$STEP1_DESCRIPTION" "${cmd[@]}"
-else
-  printf '%s' "$STEP1_PROMPT" | run_step "$STEP1_DESCRIPTION" "${cmd[@]}"
-fi
+RUN_STEP_PROMPT="$STEP1_PROMPT"
+run_step "$STEP1_DESCRIPTION" "${cmd[@]}"
 
-# Step 2: Follow the instructions in @.opencode/commands/commit-push.md
-STEP2_DESCRIPTION="Follow the instructions in @.opencode/commands/commit-push.md"
-STEP2_PROMPT="Follow the instructions in @.opencode/commands/commit-push.md"
-
+# Step 2: agent build
+STEP2_DESCRIPTION="Follow instructions in @.opencode/commands/prp-issue-fix.md for latest open issue and use its investigation comment as implementation plan"
+STEP2_PROMPT="Follow the instructions in @.opencode/commands/prp-issue-fix.md for the latest open issue on Github and take its investigation comment as the implementation plan"
 cmd=(opencode run --format json --agent build)
-if [[ "$DRY_RUN" == true ]]; then
-  run_step "$STEP2_DESCRIPTION" "${cmd[@]}"
-else
-  printf '%s' "$STEP2_PROMPT" | run_step "$STEP2_DESCRIPTION" "${cmd[@]}"
-fi
+RUN_STEP_PROMPT="$STEP2_PROMPT"
+run_step "$STEP2_DESCRIPTION" "${cmd[@]}"
 
-# Step 3: Only if the latest PR shows merge issues follow the instructions in @.opencode/commands/resolve-ci-errors.md
-STEP3_DESCRIPTION="Only if the latest PR shows merge issues follow the instructions in @.opencode/commands/resolve-ci-errors.md"
-STEP3_PROMPT="Only if the latest PR shows merge issues follow the instructions in @.opencode/commands/resolve-ci-errors.md"
-
+# Step 3: agent build
+STEP3_DESCRIPTION="Follow instructions in @.opencode/commands/commit-push.md"
+STEP3_PROMPT="Follow the instructions in @.opencode/commands/commit-push.md"
 cmd=(opencode run --format json --agent build)
-if [[ "$DRY_RUN" == true ]]; then
-  run_step "$STEP3_DESCRIPTION" "${cmd[@]}"
-else
-  printf '%s' "$STEP3_PROMPT" | run_step "$STEP3_DESCRIPTION" "${cmd[@]}"
-fi
+RUN_STEP_PROMPT="$STEP3_PROMPT"
+run_step "$STEP3_DESCRIPTION" "${cmd[@]}"
 
-# Step 4: Follow the instructions in @.opencode/commands/prp-review.md for the latest PR.
-STEP4_DESCRIPTION="Follow the instructions in @.opencode/commands/prp-review.md for the latest PR."
-STEP4_PROMPT="Follow the instructions in @.opencode/commands/prp-review.md for the latest PR."
-
+# Step 4: agent build
+STEP4_DESCRIPTION="If latest PR shows merge issues, follow @.opencode/commands/resolve-ci-errors.md"
+STEP4_PROMPT="Only if the latest PR shows merge issues follow the instructions in @.opencode/commands/resolve-ci-errors.md"
 cmd=(opencode run --format json --agent build)
-if [[ "$DRY_RUN" == true ]]; then
-  run_step "$STEP4_DESCRIPTION" "${cmd[@]}"
-else
-  printf '%s' "$STEP4_PROMPT" | run_step "$STEP4_DESCRIPTION" "${cmd[@]}"
-fi
+RUN_STEP_PROMPT="$STEP4_PROMPT"
+run_step "$STEP4_DESCRIPTION" "${cmd[@]}"
 
-# Step 5: Use the `gh` CLI to merge the latest PR if it was approved by the latest comment. Send a telegram message on the outcome.
-STEP5_DESCRIPTION="Use the \`gh\` CLI to merge the latest PR if it was approved by the latest comment. Send a telegram message on the outcome."
-STEP5_PROMPT="Use the \`gh\` CLI to merge the latest PR if it was approved by the latest comment. Send a telegram message on the outcome."
-
+# Step 5: agent build
+STEP5_DESCRIPTION="Follow instructions in @.opencode/commands/prp-review.md for latest PR"
+STEP5_PROMPT="Follow the instructions in @.opencode/commands/prp-review.md for the latest PR."
 cmd=(opencode run --format json --agent build)
-if [[ "$DRY_RUN" == true ]]; then
-  run_step "$STEP5_DESCRIPTION" "${cmd[@]}"
-else
-  printf '%s' "$STEP5_PROMPT" | run_step "$STEP5_DESCRIPTION" "${cmd[@]}"
-fi
+RUN_STEP_PROMPT="$STEP5_PROMPT"
+run_step "$STEP5_DESCRIPTION" "${cmd[@]}"
 
-# Step 6: Switch back to main and do a fresh git pull
-STEP6_DESCRIPTION="Switch back to main and do a fresh git pull"
-STEP6_PROMPT="Switch back to main and do a fresh git pull"
-
+# Step 6: agent build
+STEP6_DESCRIPTION="Raise Github issues via gh for high/critical latest PR review findings"
+STEP6_PROMPT="Raise new Github issues with \`gh\` CLI if the PR review comments of the latest PR came up with high or critical priority findings."
 cmd=(opencode run --format json --agent build)
-if [[ "$DRY_RUN" == true ]]; then
-  run_step "$STEP6_DESCRIPTION" "${cmd[@]}"
-else
-  printf '%s' "$STEP6_PROMPT" | run_step "$STEP6_DESCRIPTION" "${cmd[@]}"
-fi
+RUN_STEP_PROMPT="$STEP6_PROMPT"
+run_step "$STEP6_DESCRIPTION" "${cmd[@]}"
 
-log INFO "Workflow finished: Continuous Issue Resolution"
+# Step 7: agent build
+STEP7_DESCRIPTION="Use gh to merge latest approved PR and send telegram message if any PR processed"
+STEP7_PROMPT="Use the \`gh\` CLI to merge the latest PR if it was approved by the latest comment. If any PR was processed, send a telegram message on the outcome."
+cmd=(opencode run --format json --agent build)
+RUN_STEP_PROMPT="$STEP7_PROMPT"
+run_step "$STEP7_DESCRIPTION" "${cmd[@]}"
+
+# Step 8: agent build
+STEP8_DESCRIPTION="Switch back to main and do a fresh git pull"
+STEP8_PROMPT="Switch back to main and do a fresh git pull"
+cmd=(opencode run --format json --agent build)
+RUN_STEP_PROMPT="$STEP8_PROMPT"
+run_step "$STEP8_DESCRIPTION" "${cmd[@]}"
+
+log INFO "Workflow finished: ${WORKFLOW_NAME}"

--- a/.made/workflows.yml
+++ b/.made/workflows.yml
@@ -6,6 +6,9 @@ workflows:
   steps:
   - type: agent
     agent: build
+    prompt: If not on main, switch back to main and do a fresh git pull
+  - type: agent
+    agent: build
     prompt: Follow the instructions in @.opencode/commands/prp-issue-fix.md for the
       latest open issue on Github and take its investigation comment as the implementation
       plan
@@ -19,6 +22,10 @@ workflows:
     agent: build
     prompt: Follow the instructions in @.opencode/commands/prp-review.md for the latest
       PR.
+  - type: agent
+    agent: build
+    prompt: Raise new Github issues with `gh` CLI if the PR review comments of the
+      latest PR came up with high or critical priority findings.
   - type: agent
     agent: build
     prompt: Use the `gh` CLI to merge the latest PR if it was approved by the latest


### PR DESCRIPTION
## Problem
The automation script and `.made/workflows.yml` were no longer aligned, so workflow intent and actual execution order could drift. The shell script also repeated prompt piping logic in each step, which made step maintenance error-prone.

## Solution
Standardize workflow metadata in the harness script and make step prompt injection explicit through a single `RUN_STEP_PROMPT` path. Reorder script steps to match the intended process and mirror those changes in `.made/workflows.yml`.

## Changes
- Updated `.harness/continuous-issue-resolution.sh` argument handling, logging setup, and run-step prompt flow
- Reordered/expanded workflow steps in the script (pre-main sync first, high/critical issue creation before merge)
- Added matching workflow steps in `.made/workflows.yml`

## Testing
- `bash -n .harness/continuous-issue-resolution.sh` (passes)
- `git commit` hook ran workspace tests:
  - Backend Jest: 9/9 suites passed
  - Frontend Vitest: 10/10 files passed
- `git push` hook validations passed:
  - Linting passed
  - Type checking passed
  - Build validation passed

## Example Output
```bash
[INFO] Starting workflow: Continuous Issue Resolution
[INFO] If not on main, switch back to main and do a fresh git pull
[INFO] Follow instructions in @.opencode/commands/prp-issue-fix.md for latest open issue and use its investigation comment as implementation plan
[INFO] Follow instructions in @.opencode/commands/commit-push.md
```

## Notes
This PR keeps workflow orchestration definitions synchronized between shell harness and YAML config to reduce drift in future updates.