### PR TITLE
Fix: sanitize download filenames for security (#43)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,7 +7,7 @@ import { Layout, ContentContainer, PageHeader } from './components/Layout/Layout
 import { YouTubeDownload } from './components/YouTubeDownload';
 import { DownloadQueue } from './components/DownloadQueue';
 import { useVideos } from './hooks/useVideos';
-import { getVideoStreamUrl } from './services/api';
+import { getVideoStreamUrl, sanitizeFilename } from './services/api';
 
 // Create Query Client outside component to avoid recreation on renders
 const queryClient = new QueryClient({
@@ -83,7 +83,7 @@ function App() {
             <div className="absolute top-4 right-4 z-10 flex gap-2">
               <a
                 href={getVideoStreamUrl(selectedVideo.file.name)}
-                download={selectedVideo.file.name}
+                download={sanitizeFilename(selectedVideo.file.name)}
                 className="text-white hover:text-gray-300 text-xl p-2"
                 aria-label="Download video"
                 title="Download video"

--- a/frontend/src/__tests__/api.test.ts
+++ b/frontend/src/__tests__/api.test.ts
@@ -4,6 +4,7 @@ import {
   getVideoById, 
   getVideoStreamUrl, 
   getVideoThumbnailUrl,
+  sanitizeFilename,
   formatFileSize,
   formatDuration,
   ApiError 
@@ -146,6 +147,37 @@ describe('API Service', () => {
 
       const url = getVideoThumbnailUrl(video);
       expect(url).toBeNull();
+    });
+  });
+
+  describe('sanitizeFilename', () => {
+    test('should replace special characters with underscores', () => {
+      expect(sanitizeFilename('video<>:"/\\|?*.mp4')).toBe('video_.mp4');
+    });
+
+    test('should preserve alphanumeric and . - _ characters', () => {
+      expect(sanitizeFilename('my-video_file.MP4')).toBe('my-video_file.MP4');
+    });
+
+    test('should handle empty string', () => {
+      expect(sanitizeFilename('')).toBe('');
+    });
+
+    test('should limit filename length to 200 characters', () => {
+      const longName = 'a'.repeat(300) + '.mp4';
+      expect(sanitizeFilename(longName).length).toBe(200);
+    });
+
+    test('should collapse multiple underscores into one', () => {
+      expect(sanitizeFilename('video   with   spaces.mp4')).toBe('video_with_spaces.mp4');
+    });
+
+    test('should trim leading and trailing whitespace', () => {
+      expect(sanitizeFilename('  video.mp4  ')).toBe('video.mp4');
+    });
+
+    test('should remove path traversal separators', () => {
+      expect(sanitizeFilename('../../etc/passwd.mp4')).toBe('.._.._etc_passwd.mp4');
     });
   });
 

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -97,6 +97,14 @@ export function getVideoThumbnailUrl(video: Video): string | null {
   return `${API_BASE_URL}/thumbnails/${encodeURIComponent(video.metadata.thumbnail)}`;
 }
 
+export function sanitizeFilename(filename: string): string {
+  return filename
+    .trim()
+    .replace(/[^a-zA-Z0-9._-]/g, '_')
+    .replace(/_+/g, '_')
+    .substring(0, 200);
+}
+
 /**
  * Format file size for display
  */


### PR DESCRIPTION
## Summary

Frontend downloads used the raw `selectedVideo.file.name` in the `download` attribute, which could produce unsafe or malformed saved filenames.
This change adds frontend filename sanitization and applies it only to the `download` attribute while preserving existing stream URL encoding.

## Root Cause

`frontend/src/App.tsx` passed unsanitized filename data directly to `download={...}`.
No frontend filename sanitization utility existed to normalize special characters, whitespace, or overly long names.

## Changes

| File | Change |
|------|--------|
| `frontend/src/services/api.ts` | Added `sanitizeFilename()` utility (trim, replace unsafe chars, collapse underscores, 200-char max) |
| `frontend/src/App.tsx` | Switched download attribute to `download={sanitizeFilename(selectedVideo.file.name)}` |
| `frontend/src/__tests__/api.test.ts` | Added unit tests for sanitize behavior, including traversal-like input and edge cases |

## Testing

- [x] Type check passes
- [x] Unit tests pass
- [x] Lint passes
- [ ] Manual verification in browser

## Validation

```bash
cd frontend
npm run test
npm run type-check
npm run lint
```

## Issue

Fixes #43

---

<details>
<summary>Implementation Details</summary>

### Implementation followed investigation comment

`https://github.com/tbrandenburg/sofathek/issues/43#issuecomment-4019696535`

### Deviations from plan

- Used `filename.trim()` **before** replacement to make the whitespace-trimming requirement effective.
- Adjusted one expected test output to match the plan's own regex behavior (`replace(/_+/g, '_')` collapses consecutive underscores).

</details>

---

_Automated implementation from investigation plan_