### PR TITLE
Fix: add download button UI coverage (#42)

### DIFF
--- a/frontend/src/__tests__/YouTubeDownload.test.tsx
+++ b/frontend/src/__tests__/YouTubeDownload.test.tsx
@@ -179,6 +179,88 @@ describe('YouTubeDownload Component', () => {
     expect(submitButton).toBeDisabled();
   });
 
+  test('should have proper accessibility attributes', () => {
+    const Wrapper = createWrapper();
+
+    render(
+      <Wrapper>
+        <YouTubeDownload />
+      </Wrapper>
+    );
+
+    const button = screen.getByTestId('download-button');
+    const input = screen.getByLabelText('YouTube URL');
+
+    fireEvent.change(input, { target: { value: 'https://www.youtube.com/watch?v=test123' } });
+
+    expect(button).toHaveAttribute('type', 'submit');
+    expect(button).not.toHaveAttribute('aria-disabled');
+
+    button.focus();
+    expect(button).toHaveFocus();
+  });
+
+  test('should have correct enabled state', () => {
+    const Wrapper = createWrapper();
+
+    render(
+      <Wrapper>
+        <YouTubeDownload />
+      </Wrapper>
+    );
+
+    const button = screen.getByTestId('download-button');
+
+    expect(button).toBeDisabled();
+
+    const input = screen.getByLabelText('YouTube URL');
+    fireEvent.change(input, { target: { value: 'https://www.youtube.com/watch?v=test123' } });
+
+    expect(button).toBeEnabled();
+  });
+
+  test('should have correct disabled state during pending', () => {
+    mockUseYouTubeDownload.mockReturnValue({
+      mutate: vi.fn(),
+      isPending: true,
+      isError: false,
+      isSuccess: false,
+      error: null,
+      data: undefined,
+      reset: vi.fn()
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    const Wrapper = createWrapper();
+
+    render(
+      <Wrapper>
+        <YouTubeDownload />
+      </Wrapper>
+    );
+
+    const button = screen.getByTestId('download-button');
+    expect(button).toBeDisabled();
+    expect(button).toHaveTextContent('Starting Download...');
+  });
+
+  test('should render download button with correct attributes', () => {
+    const Wrapper = createWrapper();
+
+    render(
+      <Wrapper>
+        <YouTubeDownload />
+      </Wrapper>
+    );
+
+    const button = screen.getByTestId('download-button');
+
+    expect(button).toBeVisible();
+    expect(button).toHaveAttribute('data-testid', 'download-button');
+    expect(screen.getByRole('button', { name: /download video/i })).toBe(button);
+    expect(button).toHaveTextContent('Download Video');
+  });
+
   test('should display success message on successful download', () => {
     mockUseYouTubeDownload.mockReturnValue({
       mutate: vi.fn(),


### PR DESCRIPTION
## Summary

Issue #42 requested explicit UI test coverage for the YouTube download button. This adds focused tests for accessibility semantics, enabled/disabled state transitions, and rendering visibility.

## Root Cause

The component already had broad behavior tests, but lacked explicit assertions for button accessibility/state/rendering criteria requested in review.

## Changes

| File | Change |
|------|--------|
| `frontend/src/__tests__/YouTubeDownload.test.tsx` | Added 4 tests for button accessibility, enabled state, pending disabled state, and visibility/rendering assertions |

## Testing

- [x] Type check passes (`npm run type-check`)
- [x] Unit tests pass (`npm run test src/__tests__/YouTubeDownload.test.tsx`)
- [x] Lint passes (`npm run lint`)
- [x] Manual verification: coverage run completed (`npm run test:coverage`)

## Validation

```bash
cd frontend
npm run test src/__tests__/YouTubeDownload.test.tsx
npm run type-check
npm run lint
npm run test:coverage
```

## Issue

Fixes #42

---

<details>
<summary>📋 Implementation Details</summary>

### Implementation followed investigation comment:

`https://github.com/tbrandenburg/sofathek/issues/42#issuecomment-4019691497`

### Deviations from plan:

- Adjusted attribute assertions to match actual DOM behavior of native button elements:
  - Replaced `tabIndex="0"` attribute check with real focusability check (`button.focus()` + `toHaveFocus()`), because default-focusable buttons do not render an explicit `tabindex` attribute.
  - Replaced raw `role="button"` attribute check with semantic role query (`getByRole('button', ...)`), because native button role is implicit.

</details>

---

_Automated implementation from investigation artifact_