### PR TITLE
Fix: add null checks for video download filename

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -81,15 +81,17 @@ function App() {
           />
           <div className="relative bg-black rounded-lg overflow-hidden max-w-4xl w-full mx-4">
             <div className="absolute top-4 right-4 z-10 flex gap-2">
-              <a
-                href={getVideoStreamUrl(selectedVideo.file.name)}
-                download={sanitizeFilename(selectedVideo.file.name)}
-                className="text-white hover:text-gray-300 text-xl p-2"
-                aria-label="Download video"
-                title="Download video"
-              >
-                ↓
-              </a>
+              {selectedVideo.file?.name && (
+                <a
+                  href={getVideoStreamUrl(selectedVideo.file.name)}
+                  download={sanitizeFilename(selectedVideo.file.name)}
+                  className="text-white hover:text-gray-300 text-xl p-2"
+                  aria-label="Download video"
+                  title="Download video"
+                >
+                  ↓
+                </a>
+              )}
               <button 
                 className="text-white hover:text-gray-300 text-2xl font-bold"
                 onClick={handleClosePlayer}


### PR DESCRIPTION
## Problem
The player modal assumed every selected video had `file.name`, which could throw at runtime when malformed video data reached the UI. That caused crashes at the exact point users tried to download.

## Solution
Guard rendering of the download anchor so it only appears when `selectedVideo.file?.name` is present. This keeps the existing download flow for valid data and prevents dereferencing undefined values.

## Changes
- Updated `frontend/src/App.tsx` in the player modal action area
- Wrapped the download `<a>` element in a `selectedVideo.file?.name` conditional
- Kept existing `sanitizeFilename()` behavior and stream URL generation for valid names

## Testing
- `make test` (backend Jest suites + frontend Vitest suites completed)
- Push hook validation during `git push`:
  - Linting passed
  - Type checking passed
  - Build validation passed

## Example Output
```tsx
{selectedVideo.file?.name && (
  <a
    href={getVideoStreamUrl(selectedVideo.file.name)}
    download={sanitizeFilename(selectedVideo.file.name)}
    aria-label="Download video"
  >
    ↓
  </a>
)}
```

## Notes
This is a defensive UI fix for issue #41 and intentionally keeps behavior unchanged for valid video metadata while avoiding runtime failures for invalid payloads.