### PR TITLE
Fix: queue API returns top-level title/URL metadata (#63)

### DIFF
--- a/backend/src/__tests__/integration/routes/youtube.test.ts
+++ b/backend/src/__tests__/integration/routes/youtube.test.ts
@@ -111,6 +111,59 @@ describe('YouTube Routes', () => {
       expect(response.body.status).toBe('success');
       expect(response.body.data.totalItems).toBe(5);
       expect(response.body.data.processing).toBe(1);
+      expect(response.body.data.lastUpdated).toBe('2026-03-02T20:00:00.000Z');
+    });
+
+    it('should transform queue items with top-level url and title fields', async () => {
+      const mockQueueStatus = {
+        totalItems: 1,
+        processing: 0,
+        completed: 1,
+        failed: 0,
+        pending: 0,
+        cancelled: 0,
+        items: [{
+          id: 'queue-123',
+          request: {
+            url: 'https://www.youtube.com/watch?v=test123',
+            requestedAt: new Date('2026-03-02T20:00:00Z'),
+            requestId: 'req-123'
+          },
+          status: 'completed' as const,
+          progress: 100,
+          currentStep: 'Completed',
+          result: {
+            id: 'download-123',
+            status: 'success' as const,
+            videoPath: '/tmp/test.mp4',
+            metadata: {
+              id: 'test123',
+              title: 'Video From Metadata'
+            },
+            startedAt: new Date('2026-03-02T20:01:00Z'),
+            completedAt: new Date('2026-03-02T20:02:00Z')
+          },
+          queuedAt: new Date('2026-03-02T20:00:00Z'),
+          startedAt: new Date('2026-03-02T20:01:00Z'),
+          completedAt: new Date('2026-03-02T20:02:00Z')
+        }],
+        lastUpdated: new Date('2026-03-02T20:03:00Z')
+      };
+
+      mockDownloadQueueService.getQueueStatus.mockReturnValue(mockQueueStatus);
+
+      const response = await request(app)
+        .get('/api/youtube/queue');
+
+      expect(response.status).toBe(200);
+      expect(response.body.status).toBe('success');
+      expect(response.body.data.items).toHaveLength(1);
+      expect(response.body.data.items[0].url).toBe('https://www.youtube.com/watch?v=test123');
+      expect(response.body.data.items[0].title).toBe('Video From Metadata');
+      expect(response.body.data.items[0].queuedAt).toBe('2026-03-02T20:00:00.000Z');
+      expect(response.body.data.items[0].startedAt).toBe('2026-03-02T20:01:00.000Z');
+      expect(response.body.data.items[0].completedAt).toBe('2026-03-02T20:02:00.000Z');
+      expect(response.body.data.lastUpdated).toBe('2026-03-02T20:03:00.000Z');
     });
   });
 

--- a/backend/src/routes/youtube.ts
+++ b/backend/src/routes/youtube.ts
@@ -69,10 +69,25 @@ router.get('/queue', catchAsync(async (_req: Request, res: Response) => {
   logger.info('Fetching download queue status');
   
   const queueStatus = downloadQueueService.getQueueStatus();
+
+  const transformedItems = queueStatus.items.map(item => ({
+    ...item,
+    url: item.request.url,
+    title: item.request.title || item.result?.metadata?.title || item.request.url,
+    queuedAt: item.queuedAt instanceof Date ? item.queuedAt.toISOString() : item.queuedAt,
+    startedAt: item.startedAt instanceof Date ? item.startedAt.toISOString() : item.startedAt,
+    completedAt: item.completedAt instanceof Date ? item.completedAt.toISOString() : item.completedAt
+  }));
+
+  const transformedStatus = {
+    ...queueStatus,
+    items: transformedItems,
+    lastUpdated: queueStatus.lastUpdated instanceof Date ? queueStatus.lastUpdated.toISOString() : queueStatus.lastUpdated
+  };
   
   res.json({
     status: 'success',
-    data: queueStatus
+    data: transformedStatus
   });
 }));
 


### PR DESCRIPTION
## Summary

The queue API returned raw backend `QueueItem` objects, while the frontend queue cards expect top-level `url` and `title` fields plus ISO timestamps.
This mismatch caused completed downloads to render without title/URL metadata.

## Root Cause

`GET /api/youtube/queue` returned `request.url` and title-related values nested inside backend structures (`request` / `result.metadata`) instead of flattening them to the frontend contract.

## Changes

| File | Change |
|------|--------|
| `backend/src/routes/youtube.ts` | Transform queue response items to include top-level `url` and `title` with fallbacks; serialize queue/item timestamps to ISO strings |
| `backend/src/__tests__/integration/routes/youtube.test.ts` | Added integration assertions for transformed fields and ISO date serialization |

## Testing

- [x] Type check passes
- [x] Unit/integration tests pass
- [x] Lint passes
- [ ] Manual browser verification run

## Validation

```bash
cd backend && npm run type-check
cd backend && npm test
cd backend && npm run lint
```

## Issue

Fixes #63

---

<details>
<summary>📋 Implementation Details</summary>

### Implementation followed artifact:

Issue #63 investigation comment (`https://github.com/tbrandenburg/sofathek/issues/63#issuecomment-4059682062`)

### Deviations from plan:

- Added explicit integration assertions for top-level `url`/`title` plus timestamp serialization in queue responses.

</details>

---

_Automated implementation from investigation artifact_