### PR TITLE
Fix: Video library does not auto-refresh after successful YouTube download (#62)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -29,7 +29,7 @@ function App() {
   const [selectedVideo, setSelectedVideo] = useState<Video | null>(null);
   const [isPlayerOpen, setIsPlayerOpen] = useState(false);
 
-  const videos = videosResult?.videos || [];
+  const videos = videosResult?.videos ?? [];
 
   // Handle video selection
   const handleVideoSelect = (video: Video) => {

--- a/frontend/src/__tests__/useVideos.test.ts
+++ b/frontend/src/__tests__/useVideos.test.ts
@@ -1,5 +1,8 @@
 import { describe, test, expect, beforeEach, vi } from 'vitest';
 import { renderHook, waitFor, act } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { createElement } from 'react';
+import type { ReactNode } from 'react';
 import { useVideos, useVideo, useVideoStats } from '../hooks/useVideos';
 import { getVideos, getVideoById } from '../services/api';
 import { VideoScanResult, Video } from '../types';
@@ -12,6 +15,23 @@ vi.mock('../services/api', () => ({
 
 const mockGetVideos = vi.mocked(getVideos);
 const mockGetVideoById = vi.mocked(getVideoById);
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+      mutations: {
+        retry: false,
+      },
+    },
+  });
+
+  return function QueryWrapper({ children }: { children: ReactNode }) {
+    return createElement(QueryClientProvider, { client: queryClient }, children);
+  };
+}
 
 describe('useVideos Hook', () => {
   beforeEach(() => {
@@ -36,11 +56,11 @@ describe('useVideos Hook', () => {
 
       mockGetVideos.mockResolvedValueOnce(mockVideosResult);
 
-      const { result } = renderHook(() => useVideos());
+      const { result } = renderHook(() => useVideos(), { wrapper: createWrapper() });
 
       // Initially loading
       expect(result.current.isLoading).toBe(true);
-      expect(result.current.data).toBeNull();
+      expect(result.current.data).toBeUndefined();
       expect(result.current.error).toBeNull();
 
       // Wait for resolution
@@ -55,16 +75,20 @@ describe('useVideos Hook', () => {
 
     test('should handle error state', async () => {
       const mockError = new Error('Failed to fetch videos');
-      mockGetVideos.mockRejectedValueOnce(mockError);
+      mockGetVideos.mockRejectedValue(mockError);
 
-      const { result } = renderHook(() => useVideos());
+      const { result } = renderHook(() => useVideos(), { wrapper: createWrapper() });
 
-      await waitFor(() => {
-        expect(result.current.isLoading).toBe(false);
-      });
+      await waitFor(
+        () => {
+          expect(result.current.isError).toBe(true);
+        },
+        { timeout: 5000 }
+      );
 
-      expect(result.current.data).toBeNull();
+      expect(result.current.data).toBeUndefined();
       expect(result.current.error).toEqual(mockError);
+      expect(mockGetVideos).toHaveBeenCalledTimes(3);
     });
 
     test('should allow refetch', async () => {
@@ -75,7 +99,7 @@ describe('useVideos Hook', () => {
         scannedAt: new Date()
       });
 
-      const { result } = renderHook(() => useVideos());
+      const { result } = renderHook(() => useVideos(), { wrapper: createWrapper() });
 
       await waitFor(() => {
         expect(result.current.isLoading).toBe(false);
@@ -104,11 +128,11 @@ describe('useVideos Hook', () => {
 
       mockGetVideoById.mockResolvedValueOnce(mockVideo);
 
-      const { result } = renderHook(() => useVideo('test-1'));
+      const { result } = renderHook(() => useVideo('test-1'), { wrapper: createWrapper() });
 
       // Initially loading
       expect(result.current.isLoading).toBe(true);
-      expect(result.current.data).toBeNull();
+      expect(result.current.data).toBeUndefined();
 
       await waitFor(() => {
         expect(result.current.isLoading).toBe(false);
@@ -120,10 +144,10 @@ describe('useVideos Hook', () => {
     });
 
     test('should not fetch when id is empty', () => {
-      const { result } = renderHook(() => useVideo(''));
+      const { result } = renderHook(() => useVideo(''), { wrapper: createWrapper() });
 
       expect(result.current.isLoading).toBe(false);
-      expect(result.current.data).toBeNull();
+      expect(result.current.data).toBeUndefined();
       expect(result.current.error).toBeNull();
       expect(mockGetVideoById).not.toHaveBeenCalled();
     });
@@ -138,7 +162,7 @@ describe('useVideos Hook', () => {
 
       const { result, rerender } = renderHook(
         ({ id }) => useVideo(id),
-        { initialProps: { id: 'test-1' } }
+        { initialProps: { id: 'test-1' }, wrapper: createWrapper() }
       );
 
       await waitFor(() => {
@@ -181,7 +205,7 @@ describe('useVideos Hook', () => {
 
       mockGetVideos.mockResolvedValueOnce(mockVideos);
 
-      const { result } = renderHook(() => useVideoStats());
+      const { result } = renderHook(() => useVideoStats(), { wrapper: createWrapper() });
 
       // Initially loading
       expect(result.current.isLoading).toBe(true);
@@ -212,7 +236,7 @@ describe('useVideos Hook', () => {
 
       mockGetVideos.mockResolvedValueOnce(mockVideos);
 
-      const { result } = renderHook(() => useVideoStats());
+      const { result } = renderHook(() => useVideoStats(), { wrapper: createWrapper() });
 
       await waitFor(() => {
         expect(result.current.isLoading).toBe(false);
@@ -226,7 +250,7 @@ describe('useVideos Hook', () => {
     test('should return zero stats when loading', () => {
       mockGetVideos.mockImplementation(() => new Promise(() => {})); // Never resolves
 
-      const { result } = renderHook(() => useVideoStats());
+      const { result } = renderHook(() => useVideoStats(), { wrapper: createWrapper() });
 
       expect(result.current.isLoading).toBe(true);
       expect(result.current.totalVideos).toBe(0);

--- a/frontend/src/hooks/useVideos.ts
+++ b/frontend/src/hooks/useVideos.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { getVideos, getVideoById } from '../services/api';
 import { Video, VideoScanResult } from '../types';
 
@@ -6,76 +6,27 @@ import { Video, VideoScanResult } from '../types';
  * Hook for fetching the complete video library
  */
 export function useVideos() {
-  const [data, setData] = useState<VideoScanResult | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState<Error | null>(null);
-
-  const fetchVideos = useCallback(async () => {
-    setIsLoading(true);
-    setError(null);
-    
-    try {
-      const result = await getVideos();
-      setData(result);
-    } catch (err) {
-      setError(err instanceof Error ? err : new Error('Failed to fetch videos'));
-    } finally {
-      setIsLoading(false);
-    }
-  }, []);
-
-  useEffect(() => {
-    fetchVideos();
-  }, [fetchVideos]);
-
-  return {
-    data,
-    isLoading,
-    error,
-    refetch: fetchVideos,
-  };
+  return useQuery<VideoScanResult>({
+    queryKey: ['videos'],
+    queryFn: getVideos,
+    staleTime: 30000,
+    gcTime: 5 * 60 * 1000,
+    retry: 2,
+    refetchOnWindowFocus: true,
+  });
 }
 
 /**
  * Hook for fetching a specific video by ID
  */
 export function useVideo(id: string) {
-  const [data, setData] = useState<Video | null>(null);
-  const [isLoading, setIsLoading] = useState(!!id);
-  const [error, setError] = useState<Error | null>(null);
-
-  const fetchVideo = useCallback(async () => {
-    if (!id) return;
-    
-    setIsLoading(true);
-    setError(null);
-    
-    try {
-      const video = await getVideoById(id);
-      setData(video);
-    } catch (err) {
-      setError(err instanceof Error ? err : new Error('Failed to fetch video'));
-    } finally {
-      setIsLoading(false);
-    }
-  }, [id]);
-
-  useEffect(() => {
-    if (id) {
-      fetchVideo();
-    } else {
-      setData(null);
-      setIsLoading(false);
-      setError(null);
-    }
-  }, [id, fetchVideo]);
-
-  return {
-    data,
-    isLoading,
-    error,
-    refetch: fetchVideo,
-  };
+  return useQuery<Video>({
+    queryKey: ['video', id],
+    queryFn: () => getVideoById(id),
+    enabled: !!id,
+    staleTime: 60000,
+    retry: 2,
+  });
 }
 
 /**


### PR DESCRIPTION
## Summary

After YouTube downloads completed, the UI invalidated `['videos']` but the library hook did not subscribe to React Query, so the list stayed stale until reload. This migrates the video hooks to React Query so invalidation triggers immediate refetch.

## Root Cause

`useYouTube` invalidates `['videos']`, but `useVideos` used `useState`/`useEffect` one-time fetching and never subscribed to that cache key.

## Changes

| File | Change |
|------|--------|
| `frontend/src/hooks/useVideos.ts` | Replaced state/effect-based `useVideos` and `useVideo` with `useQuery` hooks keyed by `['videos']` and `['video', id]` |
| `frontend/src/App.tsx` | Updated videos fallback from `|| []` to `?? []` for query data handling |
| `frontend/src/__tests__/useVideos.test.ts` | Added `QueryClientProvider` wrapper and updated assertions for React Query semantics |

## Testing

- [x] Type check passes (`cd frontend && npm run type-check`)
- [x] Unit tests pass (`cd frontend && npm test -- --run`)
- [x] Lint passes (`cd frontend && npm run lint`)
- [ ] Manual verification of end-to-end YouTube download flow (not run in this CLI session)

## Validation

```bash
cd frontend && npm run type-check && npm run lint && npm test -- --run
```

## Issue

Fixes #62

---

<details>
<summary>📋 Implementation Details</summary>

### Implementation source

Investigation plan from issue comment: `https://github.com/tbrandenburg/sofathek/issues/62#issuecomment-4059685294`

### Deviations from plan

- Added updates to `frontend/src/__tests__/useVideos.test.ts` so existing hook tests remain valid after migrating to React Query.
- Local artifact file referenced in investigation metadata (`.ghar/issues/issue-62.md`) was not present in this workspace.

</details>

---

_Automated implementation from investigation artifact_