### PR TITLE
Fix: prevent empty video src rendering (#70)

### DIFF
--- a/frontend/src/__tests__/VideoPlayer.test.tsx
+++ b/frontend/src/__tests__/VideoPlayer.test.tsx
@@ -47,6 +47,33 @@ describe('VideoPlayer Component - Malformed Data Handling', () => {
     expect(downloadLink?.getAttribute('download')).toBeFalsy();
   });
 
+  test('should not render video element with empty src when file.name is missing', () => {
+    const malformedVideo = {
+      id: 'test-video',
+      file: {
+        name: undefined,
+        size: 1024000,
+        path: '/videos/test.mp4',
+        extension: 'mp4',
+        lastModified: new Date()
+      },
+      metadata: {
+        title: 'Test Video',
+        width: 1920,
+        height: 1080
+      },
+      viewCount: 0
+    } as unknown as Video;
+
+    const { container } = render(<VideoPlayer video={malformedVideo} />);
+
+    const videoElement = container.querySelector('video');
+    expect(videoElement).toBeNull();
+
+    const unavailableMessage = screen.getByText(/Video source is not available/i);
+    expect(unavailableMessage).toBeDefined();
+  });
+
   test('should hide download link when file.name is absent', () => {
     const malformedVideo = {
       id: 'test-video',

--- a/frontend/src/components/VideoPlayer/VideoPlayer.tsx
+++ b/frontend/src/components/VideoPlayer/VideoPlayer.tsx
@@ -94,7 +94,7 @@ export function VideoPlayer({
       </div>
 
       <div className="video-container">
-        {isLoading && (
+        {hasValidFile && isLoading && (
           <div className="video-loading">
             <div className="loading-spinner"></div>
             <p>Loading video...</p>
@@ -120,28 +120,35 @@ export function VideoPlayer({
           </div>
         )}
 
-        <video
-          ref={videoRef}
-          src={streamingUrl}
-          controls={controls}
-          autoPlay={autoplay}
-          onLoadStart={handleLoadStart}
-          onLoadedData={handleLoadedData}
-          onError={handleError}
-          onPlay={handlePlay}
-          onPause={handlePause}
-          onEnded={handleEnded}
-          className="video-element"
-          style={{ display: hasError ? 'none' : 'block' }}
-        >
-          <p>
-            Your browser does not support the video tag. 
-            {hasValidFile && <a href={streamingUrl} download>Download the video</a>}
-            {!hasValidFile && <span>Video unavailable</span>} instead.
-          </p>
-        </video>
+        {hasValidFile ? (
+          <video
+            ref={videoRef}
+            src={streamingUrl}
+            controls={controls}
+            autoPlay={autoplay}
+            onLoadStart={handleLoadStart}
+            onLoadedData={handleLoadedData}
+            onError={handleError}
+            onPlay={handlePlay}
+            onPause={handlePause}
+            onEnded={handleEnded}
+            className="video-element"
+            style={{ display: hasError ? 'none' : 'block' }}
+          >
+            <p>
+              Your browser does not support the video tag.
+              <a href={streamingUrl} download>Download the video</a> instead.
+            </p>
+          </video>
+        ) : (
+          <div className="video-unavailable">
+            <div className="unavailable-icon">⚠️</div>
+            <p>Video source is not available</p>
+            <p className="unavailable-hint">The video file name is missing or invalid</p>
+          </div>
+        )}
 
-        {!hasError && !isLoading && (
+        {hasValidFile && !hasError && !isLoading && (
           <div className="video-overlay">
             {!isPlaying && (
               <button

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -263,6 +263,18 @@
     @apply flex flex-col items-center justify-center min-h-72 p-8 text-center bg-gray-800 text-white;
   }
 
+  .video-unavailable {
+    @apply flex flex-col items-center justify-center min-h-72 p-8 text-center bg-gray-800 text-white;
+  }
+
+  .unavailable-icon {
+    @apply text-5xl mb-4;
+  }
+
+  .unavailable-hint {
+    @apply text-sm text-gray-300 m-0;
+  }
+
   .video-loading .loading-spinner {
     @apply border-gray-600 border-t-primary-500;
   }


### PR DESCRIPTION
## Summary

Malformed payloads with missing `file.name` still mounted a `<video src=\"\">`, which can trigger a request to the current page URL and noisy runtime behavior.

## Root Cause

`VideoPlayer` computed an invalid source for missing filenames but still always rendered the `<video>` node. Browsers then interpreted the empty source as the current document URL.

## Changes

| File | Change |
|------|--------|
| `frontend/src/components/VideoPlayer/VideoPlayer.tsx` | Render `<video>` only when `hasValidFile` is true; render explicit unavailable state otherwise; prevent loading/overlay UI for invalid sources |
| `frontend/src/__tests__/VideoPlayer.test.tsx` | Added regression test asserting no `<video>` is rendered when `file.name` is missing |
| `frontend/src/index.css` | Added styles for unavailable-state UI |

## Testing

- [x] Type check passes
- [x] Unit tests pass
- [x] Lint passes
- [ ] Manual browser verification (not run in this CLI session)

## Validation

```bash
cd frontend
npm run type-check
npm test -- src/__tests__/VideoPlayer.test.tsx
npm run lint
```

## Issue

Fixes #70

---

<details>
<summary>📋 Implementation Details</summary>

### Implementation followed artifact:

Investigation comment on issue #70 (`issuecomment-4060145022`)

### Deviations from plan:

- `npm test -- --testPathPattern=VideoPlayer` from the artifact is not supported by Vitest in this repo; used `npm test -- src/__tests__/VideoPlayer.test.tsx`.
- Added matching CSS classes for the new `video-unavailable` markup so the fallback state renders correctly.
- Artifact file path `.ghar/issues/issue-70.md` was not present locally.

</details>

---

_Automated implementation from investigation artifact_