### PR TITLE
Fix: modal null-safety handling for malformed file payloads (#61)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -83,8 +83,8 @@ function App() {
             <div className="absolute top-4 right-4 z-10 flex gap-2">
               {selectedVideo.file?.name && (
                 <a
-                  href={selectedVideo.file?.name ? getVideoStreamUrl(selectedVideo.file.name) : '#'}
-                  download={selectedVideo.file?.name ? sanitizeFilename(selectedVideo.file.name) : undefined}
+                  href={getVideoStreamUrl(selectedVideo.file.name)}
+                  download={sanitizeFilename(selectedVideo.file.name)}
                   className="text-white hover:text-gray-300 text-xl p-2"
                   aria-label="Download video"
                   title="Download video"

--- a/frontend/src/__tests__/VideoPlayer.test.tsx
+++ b/frontend/src/__tests__/VideoPlayer.test.tsx
@@ -143,4 +143,54 @@ describe('VideoPlayer Component - Malformed Data Handling', () => {
 
     expect(() => render(<VideoPlayer video={partialVideo} />)).not.toThrow();
   });
+
+  test('should show Unknown format when metadata format and file extension are missing', () => {
+    const malformedVideo = {
+      id: 'test-video',
+      file: {
+        name: 'test.mp4',
+        size: 1024000,
+        path: '/videos/test.mp4',
+        extension: undefined,
+        lastModified: new Date()
+      },
+      metadata: {
+        title: 'Test Video',
+        width: 1920,
+        height: 1080,
+        format: undefined
+      },
+      viewCount: 0
+    } as unknown as Video;
+
+    render(<VideoPlayer video={malformedVideo} />);
+
+    const formatLabel = screen.getByText('Format:');
+    const formatRow = formatLabel.closest('.metadata-item');
+    expect(formatRow?.textContent).toContain('Unknown');
+  });
+
+  test('should hide file metadata rows when optional file properties are missing', () => {
+    const malformedVideo = {
+      id: 'test-video',
+      file: {
+        name: 'test.mp4',
+        size: undefined,
+        path: '/videos/test.mp4',
+        extension: 'mp4',
+        lastModified: undefined
+      },
+      metadata: {
+        title: 'Test Video',
+        width: 1920,
+        height: 1080
+      },
+      viewCount: 0
+    } as unknown as Video;
+
+    render(<VideoPlayer video={malformedVideo} />);
+
+    expect(screen.queryByText('File Size:')).toBeNull();
+    expect(screen.queryByText('Last Modified:')).toBeNull();
+  });
 });

--- a/frontend/src/components/VideoPlayer/VideoPlayer.tsx
+++ b/frontend/src/components/VideoPlayer/VideoPlayer.tsx
@@ -164,22 +164,22 @@ export function VideoPlayer({
       </div>
 
       <div className="video-metadata">
-        <div className="metadata-item">
-          <span className="metadata-label">File Size:</span>
-          {video.file?.size !== undefined && (
-            <span className="metadata-value">{((video.file.size || 0) / (1024 * 1024)).toFixed(1)} MB</span>
-          )}
-        </div>
+        {video.file?.size !== undefined && (
+          <div className="metadata-item">
+            <span className="metadata-label">File Size:</span>
+            <span className="metadata-value">{(video.file.size / (1024 * 1024)).toFixed(1)} MB</span>
+          </div>
+        )}
         <div className="metadata-item">
           <span className="metadata-label">Format:</span>
           <span className="metadata-value">{formatText}</span>
         </div>
-        <div className="metadata-item">
-          <span className="metadata-label">Last Modified:</span>
-          {video.file?.lastModified && (
+        {video.file?.lastModified && (
+          <div className="metadata-item">
+            <span className="metadata-label">Last Modified:</span>
             <span className="metadata-value">{new Date(video.file.lastModified).toLocaleDateString()}</span>
-          )}
-        </div>
+          </div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

Issue #61 reported that malformed `video.file` payloads could still produce unsafe modal rendering paths.

## Root Cause

`VideoPlayer` metadata rows and `App` modal download link behavior were not consistently expressed as guarded render paths for malformed or partial file data, leaving gaps relative to the investigation acceptance criteria.

## Changes

| File | Change |
|------|--------|
| `frontend/src/components/VideoPlayer/VideoPlayer.tsx` | Render file size and last-modified rows only when data exists; preserve safe fallback format text |
| `frontend/src/App.tsx` | Simplify modal download anchor to rely on guarded conditional rendering when `file.name` exists |
| `frontend/src/__tests__/VideoPlayer.test.tsx` | Add regression tests for unknown format fallback and hidden optional metadata rows |

## Testing

- [x] Type check passes
- [x] Unit tests pass
- [x] Lint passes
- [ ] Manual malformed API payload verification not run in browser session

## Validation

```bash
cd frontend
npm run test -- --run src/__tests__/VideoPlayer.test.tsx
npm run test -- --run src/__tests__/VideoCard.test.tsx
npm run type-check
npm run lint
```

## Issue

Fixes #61

---

<details>
<summary>📋 Implementation Details</summary>

### Implementation followed investigation comment plan:

`https://github.com/tbrandenburg/sofathek/issues/61#issuecomment-4058635261`

### Deviations from plan:

- Investigation expected to create `frontend/src/__tests__/VideoPlayer.test.tsx`, but file already existed on `main`, so tests were extended in-place.
- Existing `VideoPlayer.tsx` already had core null-safety for `streamingUrl`; this PR focused on remaining guard-path alignment and regression coverage.

</details>

---

_Automated implementation from investigation artifact_