### PR TITLE
Fix: optimize thumbnail discovery performance for large video libraries (#40)

### DIFF
--- a/backend/src/__tests__/unit/services/videoService.test.ts
+++ b/backend/src/__tests__/unit/services/videoService.test.ts
@@ -174,6 +174,69 @@ describe('VideoService', () => {
     });
   });
 
+  describe('findThumbnailsBatch', () => {
+    const testVideos = [
+      {
+        path: '/test/videos/movie1.mp4',
+        name: 'movie1.mp4',
+        extension: 'mp4',
+        size: 1000,
+        lastModified: new Date('2024-01-01')
+      },
+      {
+        path: '/test/videos/movie2.mp4',
+        name: 'movie2.mp4',
+        extension: 'mp4',
+        size: 2000,
+        lastModified: new Date('2024-01-01')
+      },
+      {
+        path: '/test/videos/subfolder/movie3.mp4',
+        name: 'movie3.mp4',
+        extension: 'mp4',
+        size: 3000,
+        lastModified: new Date('2024-01-01')
+      }
+    ];
+
+    it('should find thumbnails for videos in same directory', async () => {
+      mockFs.readdir
+        .mockResolvedValueOnce(['movie1.mp4', 'movie1.jpg', 'movie2.png', 'thumb.png'] as any)
+        .mockResolvedValueOnce(['movie3.mp4', 'movie3.webp'] as any);
+
+      const result = await videoService.findThumbnailsBatch(testVideos as any);
+
+      expect(result.get('/test/videos/movie1.mp4')).toBe('movie1.jpg');
+      expect(result.get('/test/videos/movie2.mp4')).toBe('movie2.png');
+      expect(result.get('/test/videos/subfolder/movie3.mp4')).toBe('movie3.webp');
+    });
+
+    it('should cache directory scans', async () => {
+      mockFs.readdir.mockResolvedValue(['movie1.mp4', 'movie1.jpg'] as any);
+
+      await videoService.findThumbnailsBatch(testVideos.slice(0, 1) as any);
+      await videoService.findThumbnailsBatch(testVideos.slice(0, 1) as any);
+
+      expect(mockFs.readdir).toHaveBeenCalledTimes(1);
+    });
+
+    it('should handle missing thumbnails gracefully', async () => {
+      mockFs.readdir.mockResolvedValue(['movie1.mp4', 'other.jpg'] as any);
+
+      const result = await videoService.findThumbnailsBatch(testVideos.slice(0, 1) as any);
+
+      expect(result.has('/test/videos/movie1.mp4')).toBe(false);
+    });
+
+    it('should handle directory scan errors gracefully', async () => {
+      mockFs.readdir.mockRejectedValue(new Error('Permission denied'));
+
+      const result = await videoService.findThumbnailsBatch(testVideos.slice(0, 1) as any);
+
+      expect(result.size).toBe(0);
+    });
+  });
+
   describe('Path Resolution', () => {
     const originalCwd = process.cwd;
     const originalEnv = process.env;

--- a/backend/src/services/videoService.ts
+++ b/backend/src/services/videoService.ts
@@ -15,6 +15,9 @@ import {
  */
 export class VideoService {
   private readonly videosDirectory: string;
+  private thumbnailCache: Map<string, { files: string[]; timestamp: number }> = new Map();
+  private readonly CACHE_TTL = 5 * 60 * 1000;
+  private readonly THUMBNAIL_EXTENSIONS = ['.jpg', '.jpeg', '.png', '.webp'];
 
   constructor(videosDirectory: string) {
     this.videosDirectory = videosDirectory;
@@ -27,6 +30,7 @@ export class VideoService {
     const errors: string[] = [];
     const videos: Video[] = [];
     let totalSize = 0;
+    const videoFiles: VideoFile[] = [];
 
     try {
       // Ensure directory exists
@@ -35,7 +39,7 @@ export class VideoService {
       // Read directory contents
       const files = await fs.readdir(this.videosDirectory);
 
-      // Process each file
+      // First pass: collect all video files
       for (const filename of files) {
         try {
           const filePath = path.join(this.videosDirectory, filename);
@@ -52,16 +56,25 @@ export class VideoService {
 
           // Create video file info
           const videoFile = await this.createVideoFile(filePath, filename, stats);
-          const metadata = await this.extractMetadata(videoFile);
-          const video = this.createVideo(videoFile, metadata);
-
-          videos.push(video);
-          totalSize += videoFile.size;
+          videoFiles.push(videoFile);
 
         } catch (error) {
           const errorMessage = error instanceof Error ? error.message : String(error);
           errors.push(`Error processing ${filename}: ${errorMessage}`);
         }
+      }
+
+      // Second pass: resolve thumbnails in batches per directory
+      const thumbnailMap = await this.findThumbnailsBatch(videoFiles);
+
+      // Third pass: create videos with metadata
+      for (const videoFile of videoFiles) {
+        const thumbnail = thumbnailMap.get(videoFile.path) ?? null;
+        const metadata = await this.extractMetadata(videoFile, thumbnail);
+        const video = this.createVideo(videoFile, metadata);
+
+        videos.push(video);
+        totalSize += videoFile.size;
       }
 
     } catch (error) {
@@ -154,7 +167,7 @@ export class VideoService {
    * For Phase 1, we'll use basic filename-based metadata
    * Future phases can integrate ffprobe for detailed video analysis
    */
-  private async extractMetadata(videoFile: VideoFile): Promise<VideoMetadata> {
+  private async extractMetadata(videoFile: VideoFile, existingThumbnail?: string | null): Promise<VideoMetadata> {
     const nameWithoutExt = path.basename(videoFile.name, path.extname(videoFile.name));
     
     const title = nameWithoutExt
@@ -163,7 +176,9 @@ export class VideoService {
       .trim();
 
     // Check for existing thumbnail (jpg, jpeg, png, webp)
-    const thumbnail = await this.findThumbnail(videoFile.path);
+    const thumbnail = existingThumbnail !== undefined
+      ? existingThumbnail
+      : await this.findThumbnail(videoFile.path);
 
     return {
       title,
@@ -179,9 +194,8 @@ export class VideoService {
   private async findThumbnail(videoPath: string): Promise<string | null> {
     const videoDir = path.dirname(videoPath);
     const baseName = path.basename(videoPath, path.extname(videoPath));
-    const extensions = ['.jpg', '.jpeg', '.png', '.webp'];
     
-    for (const ext of extensions) {
+    for (const ext of this.THUMBNAIL_EXTENSIONS) {
       const thumbPath = path.join(videoDir, baseName + ext);
       try {
         await fs.access(thumbPath);
@@ -193,6 +207,66 @@ export class VideoService {
     }
     
     return null;
+  }
+
+  private groupVideosByDirectory(videos: VideoFile[]): Map<string, VideoFile[]> {
+    const groups = new Map<string, VideoFile[]>();
+
+    for (const video of videos) {
+      const dir = path.dirname(video.path);
+      if (!groups.has(dir)) {
+        groups.set(dir, []);
+      }
+      groups.get(dir)!.push(video);
+    }
+
+    return groups;
+  }
+
+  private isImageFile(filename: string): boolean {
+    const ext = path.extname(filename).toLowerCase();
+    return this.THUMBNAIL_EXTENSIONS.includes(ext);
+  }
+
+  private async getOrScanDirectory(dir: string): Promise<string[]> {
+    const cached = this.thumbnailCache.get(dir);
+    const now = Date.now();
+
+    if (cached && (now - cached.timestamp) < this.CACHE_TTL) {
+      return cached.files;
+    }
+
+    try {
+      const files = await fs.readdir(dir);
+      this.thumbnailCache.set(dir, { files, timestamp: now });
+      return files;
+    } catch {
+      return [];
+    }
+  }
+
+  async findThumbnailsBatch(videos: VideoFile[]): Promise<Map<string, string>> {
+    const results = new Map<string, string>();
+    const dirGroups = this.groupVideosByDirectory(videos);
+
+    for (const [dir, videoFiles] of dirGroups) {
+      const files = await this.getOrScanDirectory(dir);
+      const fileSet = new Set(files.filter(file => this.isImageFile(file)));
+
+      for (const videoFile of videoFiles) {
+        const baseName = path.basename(videoFile.path, path.extname(videoFile.path));
+
+        for (const ext of this.THUMBNAIL_EXTENSIONS) {
+          const candidate = baseName + ext;
+          if (fileSet.has(candidate)) {
+            results.set(videoFile.path, candidate);
+            break;
+          }
+        }
+      }
+    }
+
+    return results;
   }
 
   /**


### PR DESCRIPTION
## Summary

`VideoService.scanVideoDirectory()` previously called `fs.access()` up to four times per video through `findThumbnail()`, which scaled poorly for large libraries.
This change batches thumbnail discovery by directory and adds a short-lived cache to reduce repeated filesystem scans.

## Root Cause

Thumbnail lookup ran as sequential per-video existence checks (`O(n*4)` filesystem calls), and the scan loop invoked it for every file.

## Changes

| File | Change |
|------|--------|
| `backend/src/services/videoService.ts` | Added directory-based thumbnail batch discovery, in-memory cache with TTL, and updated scan flow to resolve thumbnails before metadata extraction |
| `backend/src/__tests__/unit/services/videoService.test.ts` | Added tests for batch thumbnail matching, cache reuse, missing thumbnails, and directory read failures |

## Testing

- [x] Type check passes
- [x] Unit tests pass
- [x] Lint passes
- [ ] Manual `/api/videos` performance verification (not run in this automation)

## Validation

```bash
cd backend && npm run type-check
cd backend && npm test -- --testPathPattern=videoService
cd backend && npm run lint
```

## Issue

Fixes #40

---

<details>
<summary>📋 Implementation Details</summary>

### Implementation followed artifact:

GitHub issue #40 investigation comment (artifact file `.ghar/issues/issue-40.md` was referenced but not present in repo)

### Deviations from plan:

- `findThumbnailsBatch` uses exact extension-priority matching (`.jpg`, `.jpeg`, `.png`, `.webp`) instead of `startsWith` matching to avoid false positives like `movie1` vs `movie10`.
- Manual API timing step from the investigation comment was not executed in this run.

</details>

---

_Automated implementation from investigation artifact_