### PR TITLE
Fix: handle case-insensitive thumbnail filename matching (#38)

### DIFF
--- a/backend/src/__tests__/integration/routes/health.test.ts
+++ b/backend/src/__tests__/integration/routes/health.test.ts
@@ -1,14 +1,36 @@
 import request from 'supertest';
 import express from 'express';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
 import healthRouter from '../../../routes/health';
 
 describe('Health Route', () => {
   let app: express.Application;
+  let testRootDir: string;
+  const originalEnv = process.env;
 
   beforeEach(() => {
+    testRootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sofathek-health-'));
+    const videosDir = path.join(testRootDir, 'videos');
+    const tempDir = path.join(testRootDir, 'temp');
+    fs.mkdirSync(videosDir, { recursive: true });
+    fs.mkdirSync(tempDir, { recursive: true });
+
+    process.env = {
+      ...originalEnv,
+      VIDEOS_DIR: videosDir,
+      TEMP_DIR: tempDir
+    };
+
     app = express();
     app.use('/', healthRouter);
     jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    fs.rmSync(testRootDir, { recursive: true, force: true });
   });
 
   describe('GET /', () => {

--- a/backend/src/__tests__/unit/services/videoService.test.ts
+++ b/backend/src/__tests__/unit/services/videoService.test.ts
@@ -132,6 +132,77 @@ describe('VideoService', () => {
     });
   });
 
+  describe('findThumbnail (case sensitivity)', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should find thumbnail with exact case match', async () => {
+      mockFs.access.mockResolvedValue(undefined);
+
+      const result = await (videoService as any).findThumbnail('/test/videos/Video.mp4');
+
+      expect(result).toBe('Video.jpg');
+      expect(mockFs.access).toHaveBeenCalledWith('/test/videos/Video.jpg');
+    });
+
+    it('should find thumbnail with case mismatch (case-insensitive)', async () => {
+      mockFs.access.mockRejectedValue(new Error('ENOENT'));
+      mockFs.readdir.mockResolvedValue(['video.jpg', 'other.png'] as any);
+
+      const result = await (videoService as any).findThumbnail('/test/videos/Video.mp4');
+
+      expect(result).toBe('video.jpg');
+    });
+
+    it('should prefer exact case match over case-insensitive', async () => {
+      mockFs.access.mockResolvedValue(undefined);
+
+      const result = await (videoService as any).findThumbnail('/test/videos/Video.mp4');
+
+      expect(result).toBe('Video.jpg');
+      expect(mockFs.readdir).not.toHaveBeenCalled();
+    });
+
+    it('should handle all caps video name', async () => {
+      mockFs.access.mockRejectedValue(new Error('ENOENT'));
+      mockFs.readdir.mockResolvedValue(['video.png', 'other.jpg'] as any);
+
+      const result = await (videoService as any).findThumbnail('/test/videos/VIDEO.AVI');
+
+      expect(result).toBe('video.png');
+    });
+
+    it('should return null when no thumbnail exists', async () => {
+      mockFs.access.mockRejectedValue(new Error('ENOENT'));
+      mockFs.readdir.mockResolvedValue(['other.jpg', 'readme.txt'] as any);
+
+      const result = await (videoService as any).findThumbnail('/test/videos/MyVideo.mp4');
+
+      expect(result).toBeNull();
+    });
+
+    it('should handle different thumbnail extensions', async () => {
+      mockFs.access
+        .mockRejectedValueOnce(new Error('ENOENT'))
+        .mockRejectedValueOnce(new Error('ENOENT'))
+        .mockResolvedValueOnce(undefined);
+
+      const result = await (videoService as any).findThumbnail('/test/videos/Video.mp4');
+
+      expect(result).toBe('Video.png');
+    });
+
+    it('should return null when directory read fails', async () => {
+      mockFs.access.mockRejectedValue(new Error('ENOENT'));
+      mockFs.readdir.mockRejectedValue(new Error('EACCES'));
+
+      const result = await (videoService as any).findThumbnail('/test/videos/Video.mp4');
+
+      expect(result).toBeNull();
+    });
+  });
+
   describe('getVideoMetadata', () => {
     it('should return metadata for valid video file', async () => {
       mockFs.stat.mockResolvedValue({

--- a/backend/src/services/videoService.ts
+++ b/backend/src/services/videoService.ts
@@ -190,20 +190,35 @@ export class VideoService {
   /**
    * Look for thumbnail file matching the video filename
    * Checks for: video-name.jpg, video-name.jpeg, video-name.png, video-name.webp
+   * First attempts exact case match, then falls back to case-insensitive search
    */
   private async findThumbnail(videoPath: string): Promise<string | null> {
     const videoDir = path.dirname(videoPath);
     const baseName = path.basename(videoPath, path.extname(videoPath));
     
     for (const ext of this.THUMBNAIL_EXTENSIONS) {
-      const thumbPath = path.join(videoDir, baseName + ext);
+      const exactThumbPath = path.join(videoDir, baseName + ext);
       try {
-        await fs.access(thumbPath);
-        // Return just the filename for the metadata
+        await fs.access(exactThumbPath);
         return baseName + ext;
       } catch {
-        // Thumbnail doesn't exist, try next extension
+        // Exact match failed, continue to case-insensitive fallback
       }
+    }
+
+    try {
+      const files = await fs.readdir(videoDir);
+      const lowerBaseName = baseName.toLowerCase();
+
+      for (const ext of this.THUMBNAIL_EXTENSIONS) {
+        const targetFilename = lowerBaseName + ext;
+        const match = files.find(file => file.toLowerCase() === targetFilename);
+        if (match) {
+          return match;
+        }
+      }
+    } catch {
+      // Directory read failed, return null
     }
     
     return null;


### PR DESCRIPTION
## Summary

`findThumbnail()` previously only checked exact-case filenames, so Linux/Unix deployments missed existing thumbnails when video and thumbnail filename casing differed.

## Root Cause

Thumbnail resolution used exact `fs.access` checks for `${baseName}${ext}` only, with no fallback when casing differed between the source video and image files.

## Changes

| File | Change |
|------|--------|
| `backend/src/services/videoService.ts` | Added case-insensitive fallback directory scan after exact-match lookup in `findThumbnail()` |
| `backend/src/__tests__/unit/services/videoService.test.ts` | Added case-sensitivity coverage for exact matches, mismatches, extension handling, and error paths |
| `backend/src/__tests__/integration/routes/health.test.ts` | Stabilized test environment setup to keep repository pre-commit validation deterministic |

## Testing

- [x] Type check passes
- [x] Unit tests pass
- [x] Lint passes
- [x] Manual verification completed for uppercase video + lowercase thumbnail lookup

## Validation

```bash
cd backend
npm run type-check
npm run test:unit
npm run lint
npm run build
mkdir -p /tmp/sofathek-issue-38 && : > /tmp/sofathek-issue-38/TEST.avi && : > /tmp/sofathek-issue-38/test.jpg
node -e "const { VideoService } = require('./dist/services/videoService'); (async () => { const svc = new VideoService('/tmp/sofathek-issue-38'); const metadata = await svc.getVideoMetadata('TEST.avi'); console.log(JSON.stringify(metadata)); })().catch(err => { console.error(err); process.exit(1); });"
rm -rf /tmp/sofathek-issue-38
```

## Issue

Fixes #38

---

<details>
<summary>📋 Implementation Details</summary>

### Implementation source

Issue #38 investigation comment: https://github.com/tbrandenburg/sofathek/issues/38#issuecomment-4019684720

### Deviations from plan

- The repo root was dirty on `main`, so implementation was done in a dedicated internal worktree branch (`.worktrees/issue-38`) to keep unrelated local changes untouched.
- `thumbnail extensions` test was adapted to the real extension order (`.jpg`, `.jpeg`, `.png`, `.webp`) in current code.
- Added a health-route integration test setup fix so required pre-commit hooks pass in this environment.

</details>

---

_Automated implementation from investigation artifact_