### PR TITLE
Fix: Harness bash steps run directly (#77)

### DIFF
--- a/.harness/continuous-issue-resolution.sh
+++ b/.harness/continuous-issue-resolution.sh
@@ -95,7 +95,7 @@ log INFO "Starting workflow: ${WORKFLOW_NAME}"
 # Step 1: bash
 STEP1_DESCRIPTION='git switch main && git pull --rebase --autostash'
 STEP1_PROMPT='git switch main && git pull --rebase --autostash'
-cmd=(opencode run --format json)
+cmd=(bash -lc "$STEP1_PROMPT")
 RUN_STEP_PROMPT="$STEP1_PROMPT"
 run_step "$STEP1_DESCRIPTION" "${cmd[@]}"
 
@@ -144,7 +144,7 @@ run_step "$STEP7_DESCRIPTION" "${cmd[@]}"
 # Step 8: bash
 STEP8_DESCRIPTION='git switch main && git pull --rebase --autostash'
 STEP8_PROMPT='git switch main && git pull --rebase --autostash'
-cmd=(opencode run --format json)
+cmd=(bash -lc "$STEP8_PROMPT")
 RUN_STEP_PROMPT="$STEP8_PROMPT"
 run_step "$STEP8_DESCRIPTION" "${cmd[@]}"
 


### PR DESCRIPTION
## Summary

Issue #77 reported that steps declared as bash in the continuous issue resolution harness were still routed through `opencode run`, which blocked the requirement for deterministic direct shell execution.

## Root Cause

The script configured Step 1 and Step 8 command arrays as `opencode run --format json`, so even bash-labeled steps were executed through the agent path.

## Changes

| File | Change |
|------|--------|
| `.harness/continuous-issue-resolution.sh` | Updated Step 1 command to `bash -lc "$STEP1_PROMPT"` |
| `.harness/continuous-issue-resolution.sh` | Updated Step 8 command to `bash -lc "$STEP8_PROMPT"` |

## Testing

- [x] Syntax check passes
- [x] Dry-run output shows Step 1 and Step 8 using `bash -lc`
- [x] Push hook validation passed (lint, type-check, build)

## Validation

```bash
bash -n .harness/continuous-issue-resolution.sh
.harness/continuous-issue-resolution.sh --dry-run
```

## Issue

Fixes #77

---

<details>
<summary>📋 Implementation Details</summary>

### Implementation followed artifact:

Issue #77 investigation comment: https://github.com/tbrandenburg/sofathek/issues/77#issuecomment-4060567474

### Deviations from plan:

- Used current working branch `fix/issue-77-harness-bash-direct-local` because repository root had pre-existing untracked `.worktrees/` entries while on `main`.

</details>

---

_Automated implementation from investigation artifact_