### PR TITLE
Fix: Add findThumbnail test coverage (#37)

### DIFF
--- a/backend/src/__tests__/unit/services/videoService.test.ts
+++ b/backend/src/__tests__/unit/services/videoService.test.ts
@@ -193,11 +193,60 @@ describe('VideoService', () => {
       expect(result).toBe('Video.png');
     });
 
+    it('should find jpeg thumbnail after jpg misses', async () => {
+      mockFs.access
+        .mockRejectedValueOnce(new Error('ENOENT'))
+        .mockResolvedValueOnce(undefined);
+
+      const result = await (videoService as any).findThumbnail('/test/videos/Video.mp4');
+
+      expect(result).toBe('Video.jpeg');
+    });
+
+    it('should find webp thumbnail after other extensions miss', async () => {
+      mockFs.access
+        .mockRejectedValueOnce(new Error('ENOENT'))
+        .mockRejectedValueOnce(new Error('ENOENT'))
+        .mockRejectedValueOnce(new Error('ENOENT'))
+        .mockResolvedValueOnce(undefined);
+
+      const result = await (videoService as any).findThumbnail('/test/videos/Video.mp4');
+
+      expect(result).toBe('Video.webp');
+    });
+
+    it('should prefer jpg over jpeg when both are accessible', async () => {
+      mockFs.access.mockResolvedValue(undefined);
+
+      const result = await (videoService as any).findThumbnail('/test/videos/Video.mp4');
+
+      expect(result).toBe('Video.jpg');
+      expect(mockFs.access).toHaveBeenCalledTimes(1);
+    });
+
+    it('should match exact thumbnail filename in fallback search', async () => {
+      mockFs.access.mockRejectedValue(new Error('ENOENT'));
+      mockFs.readdir.mockResolvedValue(['video-trailer.jpg', 'video.jpg'] as any);
+
+      const result = await (videoService as any).findThumbnail('/test/videos/video.mp4');
+
+      expect(result).toBe('video.jpg');
+    });
+
     it('should return null when directory read fails', async () => {
       mockFs.access.mockRejectedValue(new Error('ENOENT'));
       mockFs.readdir.mockRejectedValue(new Error('EACCES'));
 
       const result = await (videoService as any).findThumbnail('/test/videos/Video.mp4');
+
+      expect(result).toBeNull();
+    });
+
+    it('should return null when thumbnail directory does not exist', async () => {
+      mockFs.access.mockRejectedValue(new Error('ENOENT'));
+      mockFs.readdir.mockRejectedValue(new Error('ENOENT: no such file or directory'));
+
+      const result = await (videoService as any).findThumbnail('/nonexistent/dir/video.mp4');
 
       expect(result).toBeNull();
     });


### PR DESCRIPTION
## Summary

Issue #37 requires fuller test coverage for `VideoService.findThumbnail()` across extension priority and filesystem failure scenarios.

## Root Cause

`findThumbnail()` had partial unit coverage and was missing explicit checks for `.jpeg`, `.webp`, extension ordering (`.jpg` before `.jpeg`), exact fallback filename matching, and missing-directory behavior.

## Changes

| File | Change |
|------|--------|
| `backend/src/__tests__/unit/services/videoService.test.ts` | Added findThumbnail tests for `.jpeg` and `.webp`, explicit jpg-over-jpeg priority, exact fallback filename matching, and missing-directory handling |

## Testing

- [x] Type check passes
- [x] Unit tests pass
- [x] Lint passes
- [x] Manual verification not required

## Validation

```bash
cd backend
npm test -- --testPathPattern="videoService.test" && npm run type-check && npm run lint
```

## Issue

Fixes #37

---

<details>
<summary>📋 Implementation Details</summary>

### Implementation followed investigation comment:

Issue comment: https://github.com/tbrandenburg/sofathek/issues/37#issuecomment-4019684921

### Deviations from plan:

- The codebase had drift from the investigation snapshot: `findThumbnail` now includes case-insensitive fallback logic and already had a `findThumbnail (case sensitivity)` test block.
- Instead of adding a duplicate describe block, I extended the existing block with the missing coverage requested by the plan.
- The artifact file path `.ghar/issues/issue-37.md` was not present in the repository, so there was no local artifact file to archive.

</details>

---

_Automated implementation from investigation artifact_