### PR TITLE
Fix: frontend download status endpoint mismatch (#81)

### DIFF
--- a/frontend/src/services/youtube.ts
+++ b/frontend/src/services/youtube.ts
@@ -107,10 +107,10 @@ export async function getDownloadQueue(): Promise<QueueStatus> {
 
 /**
  * Get download status for a specific item
- * GET /api/youtube/status/:id
+ * GET /api/youtube/download/:id/status
  */
 export async function getDownloadStatus(itemId: string): Promise<QueueItem> {
-  const response = await youtubeApiFetch<QueueItem>(`/youtube/status/${encodeURIComponent(itemId)}`);
+  const response = await youtubeApiFetch<QueueItem>(`/youtube/download/${encodeURIComponent(itemId)}/status`);
   
   if (response.status !== 'success' || !response.data) {
     throw new ApiError(response.message || `Download item '${itemId}' not found`);


### PR DESCRIPTION
## Summary

The frontend was calling `/api/youtube/status/:id`, but the backend only exposes `/api/youtube/download/:id/status`, which caused 404s when polling download status.

## Root Cause

`getDownloadStatus` in `frontend/src/services/youtube.ts` used an outdated endpoint path and its JSDoc documented the same outdated contract.

## Changes

| File | Change |
|------|--------|
| `frontend/src/services/youtube.ts` | Updated `getDownloadStatus` path to `/youtube/download/${encodeURIComponent(itemId)}/status` |
| `frontend/src/services/youtube.ts` | Updated JSDoc endpoint from `/api/youtube/status/:id` to `/api/youtube/download/:id/status` |

## Testing

- [x] Type check passes
- [x] Unit/integration tests pass
- [x] Lint passes
- [x] Manual endpoint verification completed

## Validation

```bash
npm run type-check
cd backend && npm test -- youtube.test.ts
cd frontend && npm test -- youtube.test.ts
npm run lint
curl -s "http://localhost:3001/api/youtube/download/nonexistent-id/status"
curl -s "http://localhost:3001/api/youtube/status/nonexistent-id"
```

Manual verification result:
- `/api/youtube/download/nonexistent-id/status` returns structured backend error (`Download with ID ... not found`), proving route exists.
- `/api/youtube/status/nonexistent-id` returns route-not-found error, confirming old path is invalid.

## Issue

Fixes #81

---

<details>
<summary>📋 Implementation Details</summary>

### Implementation followed investigation comment:

`https://github.com/tbrandenburg/sofathek/issues/81#issuecomment-4060865766`

### Deviations from plan:

- Did not archive `.ghar/issues/issue-81.md` because that artifact file is not present in this repository checkout.

</details>

---

_Automated implementation from investigation artifact_