### PR TITLE
Fix: make backend env loading explicit (#87)

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,10 +177,22 @@ docker run --rm -v sofathek_videos:/data -v $(pwd)/backup:/backup alpine tar czf
 
 ### Environment Variables
 
+Backend environment variables are loaded from `backend/.env` at startup via `backend/src/server.ts` (`import 'dotenv/config'`).
+Start from the template:
+
+```bash
+cp backend/.env.example backend/.env
+```
+
 | Variable | Default | Description |
 |----------|---------|-------------|
+| `PORT` | `3001` | Backend server port |
+| `NODE_ENV` | `development` | Runtime environment |
+| `LOG_LEVEL` | `info` | Winston logger level |
 | `VIDEOS_PATH` | `backend/data/videos` | Path to video storage directory |
 | `VIDEOS_DIR` | (falls back to `VIDEOS_PATH`) | Alternate env var for videos |
+| `TEMP_DIR` | `backend/data/temp` | Path to temporary/transcoding files |
+| `ALLOWED_ORIGINS` | `http://localhost:5183` | Comma-separated CORS allowlist for production |
 | `THUMBNAIL_MAX_SIZE` | `10485760` (10MB) | Maximum thumbnail size in bytes; larger files return HTTP 413 |
 | `THUMBNAIL_CACHE_DURATION` | `86400` | Thumbnail cache max-age in seconds |
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,21 @@
+# Server Configuration
+PORT=3001
+NODE_ENV=development
+
+# Logging
+LOG_LEVEL=info
+
+# Storage Paths
+VIDEOS_DIR=/path/to/videos
+TEMP_DIR=/path/to/temp
+
+# Media Processing
+FFMPEG_PATH=/usr/bin/ffmpeg
+FFPROBE_PATH=/usr/bin/ffprobe
+
+# CORS (production only)
+ALLOWED_ORIGINS=http://localhost:5183,https://yourdomain.com
+
+# Thumbnail Settings
+THUMBNAIL_MAX_SIZE=10485760
+THUMBNAIL_CACHE_DURATION=86400

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -1,0 +1,34 @@
+import 'dotenv/config';
+
+interface Config {
+  port: number;
+  nodeEnv: string;
+  logLevel: string;
+  videosDir: string;
+  tempDir: string;
+  allowedOrigins: string[];
+  thumbnailMaxSize: number;
+  thumbnailCacheDuration: number;
+}
+
+function getConfig(): Config {
+  const requiredVars = ['VIDEOS_DIR', 'TEMP_DIR'];
+  const missing = requiredVars.filter((v) => !process.env[v]);
+
+  if (missing.length > 0 && process.env.NODE_ENV !== 'development') {
+    throw new Error(`Missing required environment variables: ${missing.join(', ')}`);
+  }
+
+  return {
+    port: parseInt(process.env.PORT || '3001', 10),
+    nodeEnv: process.env.NODE_ENV || 'development',
+    logLevel: process.env.LOG_LEVEL || 'info',
+    videosDir: process.env.VIDEOS_DIR || '/path/to/videos',
+    tempDir: process.env.TEMP_DIR || '/path/to/temp',
+    allowedOrigins: process.env.ALLOWED_ORIGINS?.split(',') || ['http://localhost:5183'],
+    thumbnailMaxSize: parseInt(process.env.THUMBNAIL_MAX_SIZE || '', 10) || 10 * 1024 * 1024,
+    thumbnailCacheDuration: parseInt(process.env.THUMBNAIL_CACHE_DURATION || '', 10) || 86400,
+  };
+}
+
+export const config = getConfig();

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,3 +1,4 @@
+import 'dotenv/config';
 import { startServer } from './app';
 import { logger } from './utils/logger';
 


### PR DESCRIPTION
## Summary

Backend startup now explicitly bootstraps dotenv before importing env-dependent modules, and environment variable setup is documented for local development.

## Root Cause

The backend entrypoint loaded app/logger modules before dotenv initialization, so `process.env` values used at module load time were implicit and environment-dependent.

## Changes

| File | Change |
|------|--------|
| `backend/src/server.ts` | Added `import 'dotenv/config'` as the first import |
| `backend/.env.example` | Added documented template for backend environment variables |
| `backend/src/config.ts` | Added centralized config parsing with production-time required var validation |
| `README.md` | Documented backend env loading order and `.env` setup |

## Testing

- [x] Type check passes (`cd backend && npm run type-check`)
- [x] Unit/integration tests pass (`cd backend && npm test`)
- [x] Lint passes (`cd backend && npm run lint`)
- [x] Manual verification: started backend from `.env` and confirmed `curl http://localhost:3017/health` returned healthy response
- [x] Adversarial verification: `node -e` import of `dist/config.js` in production mode fails when `VIDEOS_DIR`/`TEMP_DIR` are missing

## Validation

```bash
cd backend && npm run type-check && npm test && npm run lint
```

## Issue

Fixes #87

---

<details>
<summary>📋 Implementation Details</summary>

### Implementation followed artifact:

Issue #87 investigation comment artifact

### Deviations from plan:

- `README.md` was also updated to document env loading order and required vars.
- Artifact file path `.ghar/issues/issue-87.md` was not present in this repo; investigation comment was used directly as source of truth.

</details>

---

_Automated implementation from investigation artifact_