### PR TITLE
Fix: wire centralized backend config into runtime startup (#89)

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,14 +153,14 @@ The application stores videos in `backend/data/videos` by default. Create the di
 mkdir -p backend/data/videos
 ```
 
-To customize the video directory, set the `VIDEOS_PATH` environment variable:
+To customize the video directory, set the `VIDEOS_DIR` environment variable:
 
 ```bash
 # Linux/macOS
-export VIDEOS_PATH=/custom/path/to/videos
+export VIDEOS_DIR=/custom/path/to/videos
 
 # Windows (PowerShell)
-$env:VIDEOS_PATH = "C:\custom\path\to\videos"
+$env:VIDEOS_DIR = "C:\custom\path\to\videos"
 ```
 
 ### Docker
@@ -177,7 +177,8 @@ docker run --rm -v sofathek_videos:/data -v $(pwd)/backup:/backup alpine tar czf
 
 ### Environment Variables
 
-Backend environment variables are loaded from `backend/.env` at startup via `backend/src/server.ts` (`import 'dotenv/config'`).
+Backend environment variables are loaded from `backend/.env` at startup and read through centralized config in `backend/src/config.ts`.
+In production mode (`NODE_ENV=production`), startup fails fast if `VIDEOS_DIR` or `TEMP_DIR` is missing.
 Start from the template:
 
 ```bash
@@ -189,9 +190,8 @@ cp backend/.env.example backend/.env
 | `PORT` | `3001` | Backend server port |
 | `NODE_ENV` | `development` | Runtime environment |
 | `LOG_LEVEL` | `info` | Winston logger level |
-| `VIDEOS_PATH` | `backend/data/videos` | Path to video storage directory |
-| `VIDEOS_DIR` | (falls back to `VIDEOS_PATH`) | Alternate env var for videos |
-| `TEMP_DIR` | `backend/data/temp` | Path to temporary/transcoding files |
+| `VIDEOS_DIR` | `/path/to/videos` | Path to video storage directory (required in production) |
+| `TEMP_DIR` | `/path/to/temp` | Path to temporary/transcoding files (required in production) |
 | `ALLOWED_ORIGINS` | `http://localhost:5183` | Comma-separated CORS allowlist for production |
 | `THUMBNAIL_MAX_SIZE` | `10485760` (10MB) | Maximum thumbnail size in bytes; larger files return HTTP 413 |
 | `THUMBNAIL_CACHE_DURATION` | `86400` | Thumbnail cache max-age in seconds |

--- a/backend/src/__tests__/integration/config.test.ts
+++ b/backend/src/__tests__/integration/config.test.ts
@@ -1,0 +1,43 @@
+jest.mock('dotenv/config', () => ({}));
+
+describe('Config', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...originalEnv };
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  describe('production validation', () => {
+    it('throws when required directories are missing in production', () => {
+      process.env.NODE_ENV = 'production';
+      delete process.env.VIDEOS_DIR;
+      delete process.env.TEMP_DIR;
+
+      expect(() => {
+        jest.isolateModules(() => {
+          require('../../config');
+        });
+      }).toThrow('Missing required environment variables');
+    });
+
+    it('allows missing directories in development', () => {
+      process.env.NODE_ENV = 'development';
+      delete process.env.VIDEOS_DIR;
+      delete process.env.TEMP_DIR;
+
+      let loadedConfig: any;
+      jest.isolateModules(() => {
+        loadedConfig = require('../../config').config;
+      });
+
+      expect(loadedConfig.nodeEnv).toBe('development');
+      expect(loadedConfig.videosDir).toBe('/path/to/videos');
+      expect(loadedConfig.tempDir).toBe('/path/to/temp');
+    });
+  });
+});

--- a/backend/src/__tests__/integration/routes/health.test.ts
+++ b/backend/src/__tests__/integration/routes/health.test.ts
@@ -3,7 +3,6 @@ import express from 'express';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import healthRouter from '../../../routes/health';
 
 describe('Health Route', () => {
   let app: express.Application;
@@ -22,6 +21,9 @@ describe('Health Route', () => {
       VIDEOS_DIR: videosDir,
       TEMP_DIR: tempDir
     };
+
+    jest.resetModules();
+    const healthRouter = require('../../../routes/health').default;
 
     app = express();
     app.use('/', healthRouter);

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,5 +1,6 @@
 import express, { Application, Request, Response } from 'express';
 import cors from 'cors';
+import { config } from './config';
 import { logger } from './utils/logger';
 import { apiRouter } from './routes/api';
 import healthRouter from './routes/health';
@@ -10,8 +11,8 @@ const app: Application = express();
 
 // Set up CORS - allow all origins in development
 const corsOptions = {
-  origin: process.env.NODE_ENV === 'production' 
-    ? process.env.ALLOWED_ORIGINS?.split(',') || ['http://localhost:5183']
+  origin: config.nodeEnv === 'production'
+    ? config.allowedOrigins
     : true, // Allow all origins in development
   credentials: true,
   optionsSuccessStatus: 200
@@ -74,7 +75,7 @@ export const startServer = (port: number = 3001): Promise<any> => {
       } else {
         logger.info(`Sofathek backend server is running on port ${port}`, {
           port,
-          environment: process.env.NODE_ENV || 'development',
+          environment: config.nodeEnv,
           cors: corsOptions
         });
         resolve(server);

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -15,7 +15,7 @@ function getConfig(): Config {
   const requiredVars = ['VIDEOS_DIR', 'TEMP_DIR'];
   const missing = requiredVars.filter((v) => !process.env[v]);
 
-  if (missing.length > 0 && process.env.NODE_ENV !== 'development') {
+  if (missing.length > 0 && process.env.NODE_ENV === 'production') {
     throw new Error(`Missing required environment variables: ${missing.join(', ')}`);
   }
 

--- a/backend/src/routes/api.ts
+++ b/backend/src/routes/api.ts
@@ -1,6 +1,7 @@
 import { Router, Request, Response } from 'express';
 import fs from 'fs';
 import path from 'path';
+import { config } from '../config';
 import { VideoService } from '../services/videoService';
 import { catchAsync, AppError } from '../middleware/errorHandler';
 import { logger } from '../utils/logger';
@@ -9,10 +10,10 @@ import youtubeRouter from './youtube';
 const router = Router();
 
 // Initialize video service (in production this would come from DI container)
-const videosDirectory = process.env.VIDEOS_PATH || path.join(process.cwd(), 'data', 'videos');
+const videosDirectory = config.videosDir;
 const videoService = new VideoService(videosDirectory);
-const MAX_THUMBNAIL_SIZE = parseInt(process.env.THUMBNAIL_MAX_SIZE || '', 10) || 10 * 1024 * 1024;
-const THUMBNAIL_CACHE_DURATION = parseInt(process.env.THUMBNAIL_CACHE_DURATION || '', 10) || 86400;
+const MAX_THUMBNAIL_SIZE = config.thumbnailMaxSize;
+const THUMBNAIL_CACHE_DURATION = config.thumbnailCacheDuration;
 
 /**
  * GET /api/videos

--- a/backend/src/routes/health.ts
+++ b/backend/src/routes/health.ts
@@ -2,6 +2,7 @@ import { Router, Request, Response } from 'express';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
+import { config } from '../config';
 import { catchAsync } from '../middleware/errorHandler';
 import { logger } from '../utils/logger';
 
@@ -91,7 +92,7 @@ router.get('/', catchAsync(async (_req: Request, res: Response) => {
     timestamp: new Date().toISOString(),
     service: 'sofathek-backend',
     version: process.env.npm_package_version || '1.0.0',
-    environment: process.env.NODE_ENV || 'development',
+    environment: config.nodeEnv,
     uptime: process.uptime(),
     system: {
       platform: os.platform(),
@@ -162,14 +163,14 @@ function getMemoryInfo() {
  * Get videos directory path
  */
 function getVideosDirectory(): string {
-  return process.env.VIDEOS_DIR || process.env.VIDEOS_PATH || path.join(process.cwd(), '..', 'data', 'videos');
+  return config.videosDir;
 }
 
 /**
  * Get temporary directory path
  */
 function getTempDirectory(): string {
-  return process.env.TEMP_DIR || path.join(process.cwd(), '..', 'data', 'temp');
+  return config.tempDir;
 }
 
 /**

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,9 +1,9 @@
 import 'dotenv/config';
+import { config } from './config';
 import { startServer } from './app';
 import { logger } from './utils/logger';
 
-// Get port from environment or default to 3001
-const PORT = parseInt(process.env.PORT || '3001', 10);
+const PORT = config.port;
 
 // Start the server
 startServer(PORT)

--- a/backend/src/services/index.ts
+++ b/backend/src/services/index.ts
@@ -4,12 +4,12 @@
 import { YouTubeDownloadService } from './youTubeDownloadService';
 import { DownloadQueueService } from './downloadQueueService';
 import { ThumbnailService } from './thumbnailService';
+import { config } from '../config';
 import { logger } from '../utils/logger';
 import * as path from 'path';
 
-// Environment-based configuration
-const VIDEOS_DIR = process.env.VIDEOS_DIR || path.join(process.cwd(), 'data', 'videos');
-const TEMP_DIR = process.env.TEMP_DIR || path.join(process.cwd(), 'data', 'temp');
+const VIDEOS_DIR = config.videosDir;
+const TEMP_DIR = config.tempDir;
 const THUMBNAILS_DIR = path.join(TEMP_DIR, 'thumbnails');
 
 // Initialize services with configured directories

--- a/backend/src/services/videoService.ts
+++ b/backend/src/services/videoService.ts
@@ -1,5 +1,6 @@
 import { promises as fs } from 'fs';
 import path from 'path';
+import { config } from '../config';
 import { logger } from '../utils/logger';
 import { 
   VideoFile, 
@@ -304,5 +305,5 @@ export class VideoService {
  * Uses environment variable or default path
  */
 export const videoService = new VideoService(
-  process.env.VIDEOS_DIR || path.join(process.cwd(), 'data', 'videos')
+  config.videosDir
 );

--- a/backend/src/utils/logger.ts
+++ b/backend/src/utils/logger.ts
@@ -1,10 +1,11 @@
 import winston from 'winston';
+import { config } from '../config';
 
 /**
  * Winston logger configuration for the application
  */
 export const logger = winston.createLogger({
-  level: process.env.LOG_LEVEL || 'info',
+  level: config.logLevel,
   format: winston.format.combine(
     winston.format.timestamp(),
     winston.format.errors({ stack: true }),
@@ -21,7 +22,7 @@ export const logger = winston.createLogger({
 
 // If we're not in production then log to the `console` with the format:
 // `${info.level}: ${info.message} JSON.stringify({ ...rest }) `
-if (process.env.NODE_ENV !== 'production') {
+if (config.nodeEnv !== 'production') {
   logger.add(new winston.transports.Console({
     format: winston.format.combine(
       winston.format.colorize(),


### PR DESCRIPTION
## Summary

PR #88 introduced centralized backend config and startup validation, but runtime modules were still reading environment variables directly so production safeguards were not reliably enforced.

## Root Cause

`backend/src/config.ts` existed but was not integrated into the runtime startup path and dependent backend modules. As a result, validation for required production env vars could be bypassed by direct `process.env` access.

## Changes

| File | Change |
|------|--------|
| `backend/src/server.ts` | Import `config` at startup and use `config.port` |
| `backend/src/app.ts` | Use config for `nodeEnv` and production CORS allowlist |
| `backend/src/utils/logger.ts` | Use `config.logLevel` and `config.nodeEnv` |
| `backend/src/routes/api.ts` | Use config for video dir and thumbnail limits/cache settings |
| `backend/src/routes/health.ts` | Use config for environment, videos dir, and temp dir |
| `backend/src/services/index.ts` | Use config for service storage directories |
| `backend/src/services/videoService.ts` | Use config for default video service directory |
| `backend/src/__tests__/integration/config.test.ts` | Added production/development config validation coverage |
| `backend/src/__tests__/integration/routes/health.test.ts` | Reset modules and load router after env setup |
| `README.md` | Updated env var docs to centralized `VIDEOS_DIR`/`TEMP_DIR` config |
| `backend/src/config.ts` | Tightened required-var guard to trigger only in production |

## Testing

- [x] Type check passes
- [x] Unit/integration tests pass
- [x] Lint passes
- [x] Manual verification: production startup fails without required vars; development startup succeeds; `/health` reports config-based environment and directories

## Validation

```bash
cd backend && npm run type-check && npm test && npm run lint
```

## Issue

Fixes #89

---

<details>
<summary>📋 Implementation Details</summary>

### Implementation followed artifact:

Investigation comment on issue #89 (`https://github.com/tbrandenburg/sofathek/issues/89#issuecomment-4061025332`)

### Deviations from plan:

- Updated `backend/src/config.ts` validation condition to enforce required vars only when `NODE_ENV === 'production'` (plan used `!== 'development'`). This preserves production fail-fast behavior while preventing non-production test/runtime breakage.
- Added `backend/src/__tests__/integration/routes/health.test.ts` module reset+lazy import to ensure route config resolves test-scoped env values.
- Artifact file path (`.ghar/issues/issue-89.md`) was not present in the repo, so implementation used the issue investigation comment directly.

</details>

---

_Automated implementation from investigation artifact_