### PR TITLE
Fix: stabilize CI E2E health checks (#92)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,8 +246,14 @@ jobs:
         run: make build
         
       - name: Start production servers in background
+        env:
+          VIDEOS_DIR: /tmp/sofathek-videos
+          TEMP_DIR: /tmp/sofathek-temp
         run: |
           echo "Starting production servers for integration testing..."
+
+          # Create temp directories for health checks
+          mkdir -p /tmp/sofathek-videos /tmp/sofathek-temp
           
           # Start backend in background
           cd backend


### PR DESCRIPTION
## Summary

PR #90 Level 4 E2E failed because backend `/health` returned 503 in CI when required filesystem directories were missing.
This update aligns the E2E job runtime environment with backend health expectations.

## Root Cause

The E2E job started servers without `VIDEOS_DIR`/`TEMP_DIR`, and without creating those directories. The backend health route marks missing video/temp directory checks as critical, resulting in HTTP 503 and failing the pre-test health gate.

## Changes

| File | Change |
|------|--------|
| `.github/workflows/ci.yml` | Added `VIDEOS_DIR` and `TEMP_DIR` env vars to the Level 4 server startup step and created both directories under `/tmp` before `make dev` |

## Testing

- [x] CI-like local health validation passes (`health_http_status=200`) using `VIDEOS_DIR=/tmp/sofathek-videos TEMP_DIR=/tmp/sofathek-temp`
- [x] Repository pre-push validation passes (lint, type-check, build)
- [x] Test suites pass via git hook execution during commit

## Validation

```bash
VIDEOS_DIR=/tmp/sofathek-videos TEMP_DIR=/tmp/sofathek-temp make dev &
sleep 20
curl -f http://localhost:3010/health
```

## Issue

Fixes #92

---

<details>
<summary>📋 Implementation Details</summary>

### Implementation followed artifact:

Issue #92 investigation comment (`github-actions`, 2026-03-14T19:21:35Z)

### Deviations from plan:

None

</details>

---

_Automated implementation from investigation artifact_