### PR TITLE
Fix: PR #90 thumbnail route respects TEMP_DIR (#91)

### DIFF
--- a/backend/src/__tests__/integration/routes/thumbnails.test.ts
+++ b/backend/src/__tests__/integration/routes/thumbnails.test.ts
@@ -1,7 +1,21 @@
 import request from 'supertest';
 import express from 'express';
 import fs from 'fs';
+import path from 'path';
 import { Readable } from 'stream';
+
+const mockVideosDir = '/tmp/mock-videos-dir';
+const mockTempDir = '/tmp/mock-custom-temp-dir';
+
+jest.mock('../../../config', () => ({
+  config: {
+    videosDir: mockVideosDir,
+    tempDir: mockTempDir,
+    thumbnailMaxSize: 10 * 1024 * 1024,
+    thumbnailCacheDuration: 86400
+  }
+}));
+
 import { apiRouter } from '../../../routes/api';
 import { globalErrorHandler } from '../../../middleware/errorHandler';
 
@@ -65,7 +79,8 @@ describe('GET /api/thumbnails/:filename', () => {
     });
 
     it('should serve thumbnail from temp/thumbnails directory', async () => {
-      mockFs.existsSync.mockImplementation((candidatePath: fs.PathLike) => String(candidatePath).includes('temp/thumbnails'));
+      const tempThumbnailsDir = path.join(mockTempDir, 'thumbnails');
+      mockFs.existsSync.mockImplementation((candidatePath: fs.PathLike) => String(candidatePath).startsWith(tempThumbnailsDir));
       mockFs.statSync.mockReturnValue({ size: 75000, isFile: () => true } as any);
 
       const response = await request(app)
@@ -73,6 +88,19 @@ describe('GET /api/thumbnails/:filename', () => {
         .expect(200);
 
       expect(response.headers['content-type']).toBe('image/png');
+    });
+
+    it('should serve thumbnail from custom TEMP_DIR', async () => {
+      const expectedTempThumbPath = path.join(mockTempDir, 'thumbnails', 'custom-thumb.jpg');
+      mockFs.existsSync.mockImplementation((candidatePath: fs.PathLike) => String(candidatePath) === expectedTempThumbPath);
+      mockFs.statSync.mockReturnValue({ size: 42000, isFile: () => true } as any);
+
+      const response = await request(app)
+        .get('/api/thumbnails/custom-thumb.jpg')
+        .expect(200);
+
+      expect(response.headers['content-type']).toBe('image/jpeg');
+      expect(mockFs.existsSync).toHaveBeenCalledWith(expectedTempThumbPath);
     });
 
     it('should return correct MIME type for jpeg', async () => {

--- a/backend/src/routes/api.ts
+++ b/backend/src/routes/api.ts
@@ -11,6 +11,7 @@ const router = Router();
 
 // Initialize video service (in production this would come from DI container)
 const videosDirectory = config.videosDir;
+const tempDirectory = config.tempDir;
 const videoService = new VideoService(videosDirectory);
 const MAX_THUMBNAIL_SIZE = config.thumbnailMaxSize;
 const THUMBNAIL_CACHE_DURATION = config.thumbnailCacheDuration;
@@ -150,7 +151,7 @@ router.get('/thumbnails/:filename', catchAsync(async (req: Request, res: Respons
   const videosThumbPath = path.join(videosDirectory, filename);
   
   // Check in temp/thumbnails (generated thumbnails)
-  const tempThumbPath = path.join(process.cwd(), 'data', 'temp', 'thumbnails', filename);
+  const tempThumbPath = path.join(tempDirectory, 'thumbnails', filename);
   
   let thumbnailPath: string | null = null;
   
@@ -168,7 +169,7 @@ router.get('/thumbnails/:filename', catchAsync(async (req: Request, res: Respons
   const resolvedVideosPath = path.resolve(videosThumbPath);
   const resolvedTempPath = path.resolve(tempThumbPath);
   const allowedVideosDir = path.resolve(videosDirectory);
-  const allowedTempDir = path.resolve(process.cwd(), 'data', 'temp', 'thumbnails');
+  const allowedTempDir = path.resolve(tempDirectory, 'thumbnails');
   
   const isInVideosDir = resolvedVideosPath.startsWith(allowedVideosDir);
   const isInTempDir = resolvedTempPath.startsWith(allowedTempDir);


### PR DESCRIPTION
## Summary

The thumbnail endpoint used hardcoded `process.cwd()/data/temp/thumbnails` paths, which bypassed runtime temp directory configuration and broke deployments using custom `TEMP_DIR`.

## Root Cause

`backend/src/routes/api.ts` resolved generated thumbnail lookup and path-allowlist checks from hardcoded cwd-relative paths instead of the centralized runtime config.

## Changes

| File | Change |
|------|--------|
| `backend/src/routes/api.ts` | Added `tempDirectory` from config and switched generated-thumbnail lookup + allowlist checks to use it |
| `backend/src/__tests__/integration/routes/thumbnails.test.ts` | Added integration coverage asserting generated thumbnails are resolved from a custom configured temp directory |

## Testing

- [x] `cd backend && npm run type-check`
- [x] `cd backend && npm test -- --testPathPattern=\"thumbnails\"`
- [x] `cd backend && npm run lint`
- [x] `npm test` (repo pre-commit hook)
- [x] `git push` validation hook (`lint`, `type-check`, `build`) passed

## Validation

```bash
cd backend && npm run type-check && npm test -- --testPathPattern="thumbnails" && npm run lint
```

## Issue

Fixes #91

---

<details>
<summary>📋 Implementation Details</summary>

### Implementation source

Investigation plan from issue #91 comment by `github-actions` (2026-03-14T19:21:30Z).

### Deviations from plan

- Used `config.tempDir` in `api.ts` instead of introducing a direct `process.env.TEMP_DIR` constant because `api.ts` now follows centralized config access (`config.videosDir`, `config.thumbnailMaxSize`, etc.).
- Added mocked integration coverage in existing `thumbnails.test.ts` style rather than filesystem-backed test setup, to stay consistent with the current route test harness.

</details>

---

_Automated implementation from investigation artifact_