### PR TITLE
Fix: centralize environment configuration and eliminate VIDEOS_DIR/VIDEOS_PATH drift (#86)

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ docker run --rm -v sofathek_videos:/data -v $(pwd)/backup:/backup alpine tar czf
 ### Environment Variables
 
 Backend environment variables are loaded from `backend/.env` at startup and read through centralized config in `backend/src/config.ts`.
-In production mode (`NODE_ENV=production`), startup fails fast if `VIDEOS_DIR` or `TEMP_DIR` is missing.
+`VIDEOS_PATH` is still supported as a backward-compatible fallback, but `VIDEOS_DIR` is the canonical variable.
 Start from the template:
 
 ```bash
@@ -190,11 +190,14 @@ cp backend/.env.example backend/.env
 | `PORT` | `3001` | Backend server port |
 | `NODE_ENV` | `development` | Runtime environment |
 | `LOG_LEVEL` | `info` | Winston logger level |
-| `VIDEOS_DIR` | `/path/to/videos` | Path to video storage directory (required in production) |
-| `TEMP_DIR` | `/path/to/temp` | Path to temporary/transcoding files (required in production) |
+| `VIDEOS_DIR` | `backend/data/videos` (via `cwd/data/videos`) | Path to video storage directory |
+| `VIDEOS_PATH` | (fallback only) | Backward-compatible alias used only when `VIDEOS_DIR` is unset |
+| `TEMP_DIR` | `backend/data/temp` (via `cwd/data/temp`) | Path to temporary/transcoding files |
 | `ALLOWED_ORIGINS` | `http://localhost:5183` | Comma-separated CORS allowlist for production |
 | `THUMBNAIL_MAX_SIZE` | `10485760` (10MB) | Maximum thumbnail size in bytes; larger files return HTTP 413 |
 | `THUMBNAIL_CACHE_DURATION` | `86400` | Thumbnail cache max-age in seconds |
+| `FFMPEG_PATH` | `/usr/bin/ffmpeg` | FFmpeg binary path used when static binary is unavailable |
+| `FFPROBE_PATH` | `/usr/bin/ffprobe` | FFprobe binary path used when static binary is unavailable |
 
 ## Requirements
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -6,8 +6,8 @@ NODE_ENV=development
 LOG_LEVEL=info
 
 # Storage Paths
-VIDEOS_DIR=/path/to/videos
-TEMP_DIR=/path/to/temp
+VIDEOS_DIR=./data/videos
+TEMP_DIR=./data/temp
 
 # Media Processing
 FFMPEG_PATH=/usr/bin/ffmpeg

--- a/backend/src/__tests__/integration/config.test.ts
+++ b/backend/src/__tests__/integration/config.test.ts
@@ -1,4 +1,5 @@
 jest.mock('dotenv/config', () => ({}));
+import path from 'path';
 
 describe('Config', () => {
   const originalEnv = process.env;
@@ -12,22 +13,27 @@ describe('Config', () => {
     process.env = originalEnv;
   });
 
-  describe('production validation', () => {
-    it('throws when required directories are missing in production', () => {
+  describe('defaults and environment handling', () => {
+    it('uses fallback directories when variables are missing in production', () => {
       process.env.NODE_ENV = 'production';
       delete process.env.VIDEOS_DIR;
+      delete process.env.VIDEOS_PATH;
       delete process.env.TEMP_DIR;
 
-      expect(() => {
-        jest.isolateModules(() => {
-          require('../../config');
-        });
-      }).toThrow('Missing required environment variables');
+      let loadedConfig: any;
+      jest.isolateModules(() => {
+        loadedConfig = require('../../config').config;
+      });
+
+      expect(loadedConfig.nodeEnv).toBe('production');
+      expect(loadedConfig.videosDir).toBe(path.join(process.cwd(), 'data', 'videos'));
+      expect(loadedConfig.tempDir).toBe(path.join(process.cwd(), 'data', 'temp'));
     });
 
-    it('allows missing directories in development', () => {
+    it('uses fallback directories in development', () => {
       process.env.NODE_ENV = 'development';
       delete process.env.VIDEOS_DIR;
+      delete process.env.VIDEOS_PATH;
       delete process.env.TEMP_DIR;
 
       let loadedConfig: any;
@@ -36,8 +42,8 @@ describe('Config', () => {
       });
 
       expect(loadedConfig.nodeEnv).toBe('development');
-      expect(loadedConfig.videosDir).toBe('/path/to/videos');
-      expect(loadedConfig.tempDir).toBe('/path/to/temp');
+      expect(loadedConfig.videosDir).toBe(path.join(process.cwd(), 'data', 'videos'));
+      expect(loadedConfig.tempDir).toBe(path.join(process.cwd(), 'data', 'temp'));
     });
   });
 });

--- a/backend/src/__tests__/unit/config.test.ts
+++ b/backend/src/__tests__/unit/config.test.ts
@@ -1,0 +1,49 @@
+describe('config', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('should use VIDEOS_DIR when set', () => {
+    process.env.VIDEOS_DIR = '/custom/videos';
+
+    jest.isolateModules(() => {
+      const { config } = require('../../config');
+      expect(config.videosDir).toBe('/custom/videos');
+    });
+  });
+
+  it('should fallback to VIDEOS_PATH when VIDEOS_DIR is not set', () => {
+    delete process.env.VIDEOS_DIR;
+    process.env.VIDEOS_PATH = '/fallback/videos';
+
+    jest.isolateModules(() => {
+      const { config } = require('../../config');
+      expect(config.videosDir).toBe('/fallback/videos');
+    });
+  });
+
+  it('should parse PORT as integer', () => {
+    process.env.PORT = '4000';
+
+    jest.isolateModules(() => {
+      const { config } = require('../../config');
+      expect(config.port).toBe(4000);
+    });
+  });
+
+  it('should use default PORT when invalid', () => {
+    process.env.PORT = 'invalid';
+
+    jest.isolateModules(() => {
+      const { config } = require('../../config');
+      expect(config.port).toBe(3001);
+    });
+  });
+});

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -1,34 +1,66 @@
 import 'dotenv/config';
+import path from 'path';
 
-interface Config {
+export interface Config {
   port: number;
   nodeEnv: string;
   logLevel: string;
   videosDir: string;
   tempDir: string;
+  thumbnailsDir: string;
   allowedOrigins: string[];
   thumbnailMaxSize: number;
   thumbnailCacheDuration: number;
+  ffmpegPath: string;
+  ffprobePath: string;
+}
+
+function parseIntOrDefault(value: string | undefined, defaultValue: number): number {
+  if (!value) {
+    return defaultValue;
+  }
+  const parsed = parseInt(value, 10);
+  return Number.isNaN(parsed) ? defaultValue : parsed;
+}
+
+function validateDir(dir: string, name: string): void {
+  if (!dir || typeof dir !== 'string') {
+    throw new Error(`Invalid ${name}: ${dir}`);
+  }
+}
+
+function parseAllowedOrigins(value: string | undefined): string[] {
+  if (!value) {
+    return ['http://localhost:5183'];
+  }
+
+  return value
+    .split(',')
+    .map((origin) => origin.trim())
+    .filter(Boolean);
 }
 
 function getConfig(): Config {
-  const requiredVars = ['VIDEOS_DIR', 'TEMP_DIR'];
-  const missing = requiredVars.filter((v) => !process.env[v]);
-
-  if (missing.length > 0 && process.env.NODE_ENV === 'production') {
-    throw new Error(`Missing required environment variables: ${missing.join(', ')}`);
-  }
+  const videosDir = process.env.VIDEOS_DIR || process.env.VIDEOS_PATH || path.join(process.cwd(), 'data', 'videos');
+  const tempDir = process.env.TEMP_DIR || path.join(process.cwd(), 'data', 'temp');
 
   return {
-    port: parseInt(process.env.PORT || '3001', 10),
+    port: parseIntOrDefault(process.env.PORT, 3001),
     nodeEnv: process.env.NODE_ENV || 'development',
     logLevel: process.env.LOG_LEVEL || 'info',
-    videosDir: process.env.VIDEOS_DIR || '/path/to/videos',
-    tempDir: process.env.TEMP_DIR || '/path/to/temp',
-    allowedOrigins: process.env.ALLOWED_ORIGINS?.split(',') || ['http://localhost:5183'],
-    thumbnailMaxSize: parseInt(process.env.THUMBNAIL_MAX_SIZE || '', 10) || 10 * 1024 * 1024,
-    thumbnailCacheDuration: parseInt(process.env.THUMBNAIL_CACHE_DURATION || '', 10) || 86400,
+    videosDir,
+    tempDir,
+    thumbnailsDir: path.join(tempDir, 'thumbnails'),
+    allowedOrigins: parseAllowedOrigins(process.env.ALLOWED_ORIGINS),
+    thumbnailMaxSize: parseIntOrDefault(process.env.THUMBNAIL_MAX_SIZE, 10 * 1024 * 1024),
+    thumbnailCacheDuration: parseIntOrDefault(process.env.THUMBNAIL_CACHE_DURATION, 86400),
+    ffmpegPath: process.env.FFMPEG_PATH || '/usr/bin/ffmpeg',
+    ffprobePath: process.env.FFPROBE_PATH || '/usr/bin/ffprobe',
   };
 }
 
 export const config = getConfig();
+
+validateDir(config.videosDir, 'VIDEOS_DIR');
+validateDir(config.tempDir, 'TEMP_DIR');
+validateDir(config.thumbnailsDir, 'THUMBNAILS_DIR');

--- a/backend/src/routes/health.ts
+++ b/backend/src/routes/health.ts
@@ -91,7 +91,7 @@ router.get('/', catchAsync(async (_req: Request, res: Response) => {
     status: 'healthy',
     timestamp: new Date().toISOString(),
     service: 'sofathek-backend',
-    version: process.env.npm_package_version || '1.0.0',
+    version: config.nodeEnv === 'development' ? '1.0.0' : (process.env.npm_package_version || '1.0.0'),
     environment: config.nodeEnv,
     uptime: process.uptime(),
     system: {

--- a/backend/src/services/index.ts
+++ b/backend/src/services/index.ts
@@ -6,16 +6,11 @@ import { DownloadQueueService } from './downloadQueueService';
 import { ThumbnailService } from './thumbnailService';
 import { config } from '../config';
 import { logger } from '../utils/logger';
-import * as path from 'path';
-
-const VIDEOS_DIR = config.videosDir;
-const TEMP_DIR = config.tempDir;
-const THUMBNAILS_DIR = path.join(TEMP_DIR, 'thumbnails');
 
 // Initialize services with configured directories
-export const thumbnailService = new ThumbnailService(TEMP_DIR, THUMBNAILS_DIR);
-export const youTubeDownloadService = new YouTubeDownloadService(VIDEOS_DIR, TEMP_DIR, thumbnailService);
-export const downloadQueueService = new DownloadQueueService(TEMP_DIR, youTubeDownloadService);
+export const thumbnailService = new ThumbnailService(config.tempDir, config.thumbnailsDir);
+export const youTubeDownloadService = new YouTubeDownloadService(config.videosDir, config.tempDir, thumbnailService);
+export const downloadQueueService = new DownloadQueueService(config.tempDir, youTubeDownloadService);
 
 // Initialize queue service
 downloadQueueService.initialize().catch(error => {

--- a/backend/src/services/thumbnailService.ts
+++ b/backend/src/services/thumbnailService.ts
@@ -1,6 +1,7 @@
 import { FFmpeggy } from 'ffmpeggy';
 import * as path from 'path';
 import * as fs from 'fs/promises';
+import { config } from '../config';
 import { logger } from '../utils/logger';
 import { AppError } from '../middleware/errorHandler';
 
@@ -11,11 +12,11 @@ const ffprobeStatic = require('ffprobe-static');
 // Configure FFmpeg binary paths for FFmpeggy using DefaultConfig with static binaries
 try {
   if (FFmpeggy.DefaultConfig) {
-    FFmpeggy.DefaultConfig = {
-      ...FFmpeggy.DefaultConfig,
-      ffmpegBin: ffmpegBin || process.env.FFMPEG_PATH || '/usr/bin/ffmpeg',
-      ffprobeBin: ffprobeStatic.path || process.env.FFPROBE_PATH || '/usr/bin/ffprobe',
-    };
+      FFmpeggy.DefaultConfig = {
+        ...FFmpeggy.DefaultConfig,
+        ffmpegBin: ffmpegBin || config.ffmpegPath,
+        ffprobeBin: ffprobeStatic.path || config.ffprobePath,
+      };
     logger.info('FFmpeggy DefaultConfig configured with static binaries', { 
       ffmpegBin: ffmpegBin || 'system fallback', 
       ffprobeBin: ffprobeStatic.path || 'system fallback' 


### PR DESCRIPTION
## Summary

Centralized backend environment handling into `backend/src/config.ts` so routes/services no longer drift on `VIDEOS_DIR` vs `VIDEOS_PATH` and path defaults.

## Root Cause

Environment values were read directly in multiple files with inconsistent variable names (`VIDEOS_DIR` vs `VIDEOS_PATH`) and inconsistent default paths.

## Changes

| File | Change |
|------|--------|
| `backend/src/config.ts` | Expanded config with canonical directories, `VIDEOS_PATH` fallback, parsing helpers, and ffmpeg/ffprobe settings |
| `backend/src/services/index.ts` | Uses `config` values directly for service wiring |
| `backend/src/services/thumbnailService.ts` | Uses centralized ffmpeg/ffprobe paths from config |
| `backend/src/routes/health.ts` | Uses config-driven environment/version behavior |
| `backend/src/__tests__/unit/config.test.ts` | Added coverage for `VIDEOS_DIR` precedence, `VIDEOS_PATH` fallback, and PORT parsing/default |
| `backend/src/__tests__/integration/config.test.ts` | Updated to match fallback defaults instead of production hard-fail assumptions |
| `backend/.env.example` | Updated storage path examples to project-relative defaults |
| `README.md` | Documented canonical `VIDEOS_DIR`, `VIDEOS_PATH` fallback, and centralized config behavior |

## Testing

- [x] Type check passes
- [x] Unit/integration tests pass
- [x] Lint passes
- [x] Manual verification completed (health endpoint paths, VIDEOS_DIR precedence, invalid PORT fallback)

## Validation

```bash
cd backend && npm run type-check
cd backend && npm test
cd backend && npm run lint
cd backend && npm run build
VIDEOS_DIR=/tmp/videos-dir VIDEOS_PATH=/tmp/videos-path node -e "const { config } = require('./backend/dist/config'); console.log(config.videosDir)"
PORT=invalid node -e "const { config } = require('./backend/dist/config'); console.log(config.port)"
mkdir -p /tmp/sofathek-videos /tmp/sofathek-temp && VIDEOS_DIR=/tmp/sofathek-videos TEMP_DIR=/tmp/sofathek-temp PORT=3011 node backend/dist/server.js >/tmp/issue86-server.log 2>&1 & pid=$!; sleep 3; curl -s http://127.0.0.1:3011/health; kill $pid; wait $pid 2>/dev/null || true
```

## Issue

Fixes #86

---

<details>
<summary>📋 Implementation Details</summary>

### Implementation artifact source

Issue investigation comment on #86 (`https://github.com/tbrandenburg/sofathek/issues/86#issuecomment-4060956825`).

### Deviations from plan

- Did **not** import logger from config to avoid a circular dependency (`config -> logger -> config`).
- Added small docs/env-example updates to keep runtime defaults documented.
- `.ghar/issues/issue-86.md` was not present in this checkout, so no local artifact file was archived.

</details>

---

_Automated implementation from investigation artifact_