### PR TITLE
Fix: remove duplicated catchAsync in youtube routes (#85)

### DIFF
--- a/backend/src/__tests__/unit/middleware/errorHandler.test.ts
+++ b/backend/src/__tests__/unit/middleware/errorHandler.test.ts
@@ -133,3 +133,29 @@ describe('Error Handler', () => {
     });
   });
 });
+
+describe('catchAsync', () => {
+  it('should be exported from errorHandler middleware', () => {
+    const errorHandler = require('../../../middleware/errorHandler');
+
+    expect(errorHandler.catchAsync).toBeDefined();
+    expect(typeof errorHandler.catchAsync).toBe('function');
+  });
+
+  it('should catch errors and pass to next middleware', async () => {
+    const { catchAsync } = require('../../../middleware/errorHandler');
+    const mockReq = {} as Request;
+    const mockRes = {} as Response;
+    const mockNext = jest.fn();
+
+    const handler = catchAsync(async () => {
+      throw new Error('Test error');
+    });
+
+    handler(mockReq, mockRes, mockNext);
+
+    await new Promise(resolve => setTimeout(resolve, 10));
+
+    expect(mockNext).toHaveBeenCalledWith(expect.any(Error));
+  });
+});

--- a/backend/src/routes/youtube.ts
+++ b/backend/src/routes/youtube.ts
@@ -1,20 +1,11 @@
 import { Router, Request, Response } from 'express';
 import { v4 as uuidv4 } from 'uuid';
 import { logger } from '../utils/logger';
-import { AppError } from '../middleware/errorHandler';
+import { catchAsync, AppError } from '../middleware/errorHandler';
 import { downloadQueueService, youTubeDownloadService } from '../services/index';
 import { DownloadRequest } from '../types/youtube';
 
 const router = Router();
-
-/**
- * Async error handler wrapper
- */
-const catchAsync = (fn: (req: Request, res: Response, next: any) => Promise<any>) => {
-  return (req: Request, res: Response, next: any) => {
-    Promise.resolve(fn(req, res, next)).catch(next);
-  };
-};
 
 /**
  * POST /api/youtube/download


### PR DESCRIPTION
## Summary

`backend/src/routes/youtube.ts` had a local `catchAsync` wrapper despite a shared middleware implementation already existing. This change removes the duplicate and standardizes route error handling on the shared helper.

## Root Cause

The YouTube routes were authored with a local helper instead of importing `catchAsync` from `backend/src/middleware/errorHandler.ts`, creating a maintainability risk where async error handling could drift across route modules.

## Changes

| File | Change |
|------|--------|
| `backend/src/routes/youtube.ts` | Replaced local `catchAsync` definition with `catchAsync` import from shared middleware |
| `backend/src/__tests__/unit/middleware/errorHandler.test.ts` | Added tests asserting `catchAsync` is exported and forwards async errors to `next` |

## Testing

- [x] Type check passes
- [x] Unit tests pass
- [x] Lint passes
- [x] Manual verification completed via route-level integration suite

## Validation

```bash
cd backend
npm run type-check
npm test -- --testPathPattern="errorHandler"
npm run lint
npm test -- --testPathPattern="integration/routes/youtube"
```

## Issue

Fixes #85

---

<details>
<summary>📋 Implementation Details</summary>

### Implementation followed artifact:

`.ghar/issues/issue-85.md`

### Deviations from plan:

Used `npm test -- --testPathPattern="integration/routes/youtube"` for endpoint verification instead of starting `make dev` and manual endpoint probing.

</details>

---

_Automated implementation from investigation artifact_