### PR TITLE
Fix: handle EPERM as HTTP 403 in thumbnail endpoint (#101)

### DIFF
--- a/backend/src/__tests__/integration/routes/thumbnails.test.ts
+++ b/backend/src/__tests__/integration/routes/thumbnails.test.ts
@@ -208,6 +208,38 @@ describe('GET /api/thumbnails/:filename', () => {
       const errorMessage = response.body.error?.message || response.body.message;
       expect(errorMessage).toContain('Permission denied');
     });
+
+    it('should return 403 for EPERM access denied', async () => {
+      mockFs.statSync.mockImplementation(() => {
+        const err = new Error('Operation not permitted') as NodeJS.ErrnoException;
+        err.code = 'EPERM';
+        throw err;
+      });
+
+      const response = await request(app)
+        .get('/api/thumbnails/forbidden-eperm.jpg')
+        .expect(403);
+
+      expect(response.body.status).toBe('error');
+      const errorMessage = response.body.error?.message || response.body.message;
+      expect(errorMessage).toContain('Permission denied');
+    });
+
+    it('should return 403 when stat access is denied with EPERM', async () => {
+      mockFs.statSync.mockImplementation(() => {
+        const err = new Error('Operation not permitted') as NodeJS.ErrnoException;
+        err.code = 'EPERM';
+        throw err;
+      });
+
+      const response = await request(app)
+        .get('/api/thumbnails/forbidden-stat-eperm.jpg')
+        .expect(403);
+
+      expect(response.body.status).toBe('error');
+      const errorMessage = response.body.error?.message || response.body.message;
+      expect(errorMessage).toContain('Permission denied');
+    });
   });
 
   describe('Security Tests', () => {

--- a/backend/src/routes/api.ts
+++ b/backend/src/routes/api.ts
@@ -169,7 +169,7 @@ router.get('/thumbnails/:filename', catchAsync(async (req: Request, res: Respons
       if (fsError.code === 'ENOENT') {
         continue;
       }
-      if (fsError.code === 'EACCES') {
+      if (fsError.code === 'EACCES' || fsError.code === 'EPERM') {
         throw new AppError('Permission denied accessing thumbnail', 403);
       }
       throw new AppError('Unable to access thumbnail', 500);


### PR DESCRIPTION
## Summary

`GET /api/thumbnails/:filename` returned HTTP 500 for permission-denied filesystem errors surfaced as `EPERM` on some platforms.

## Root Cause

The thumbnail route only treated `EACCES` as permission denied and mapped all other `fs.statSync` errors to HTTP 500, so `EPERM` was incorrectly handled as a server error.

## Changes

| File | Change |
|------|--------|
| `backend/src/routes/api.ts` | Updated thumbnail permission guard to treat `EPERM` the same as `EACCES` and return 403 |
| `backend/src/__tests__/integration/routes/thumbnails.test.ts` | Added two EPERM integration tests mirroring existing EACCES scenarios |

## Testing

- [x] Type check passes
- [x] Unit/integration tests pass
- [x] Lint passes
- [ ] Manual verification with platform-level EPERM file permissions (not executed in CI environment)

## Validation

```bash
cd backend && npm test -- --testPathPattern="thumbnails"
cd backend && npm test
cd backend && npm run lint
```

## Issue

Fixes #101

---

<details>
<summary>📋 Implementation Details</summary>

### Implementation followed artifact:

Issue investigation comment: https://github.com/tbrandenburg/sofathek/issues/101#issuecomment-4062908556

### Deviations from plan:

None

</details>

---

_Automated implementation from investigation artifact_