### PR TITLE
Fix: add real backend YouTube integration test coverage (#12)

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ npm run validate:skip   # Emergency skip
 - `frontend/tests/youtube-download/full-workflow.spec.ts` - mocked UI workflow tests (fast)
 - `frontend/tests/youtube-download/integration.spec.ts` - live frontend-backend integration tests (no external YouTube dependency)
 - `frontend/tests/youtube-download/real-world.spec.ts` - real YouTube download end-to-end tests (slow)
+- `backend/src/__tests__/integration/routes/youtube.integration.test.ts` - real backend API integration tests with actual yt-dlp download (slow)
 
 Additional details: `frontend/tests/README.md`.
 

--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -20,5 +20,5 @@ module.exports = {
   // Coverage will still be collected but not enforced
   setupFilesAfterEnv: ['<rootDir>/src/__tests__/setup.ts'],
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
-  testTimeout: 10000
+  testTimeout: 120000
 };

--- a/backend/src/__tests__/integration/routes/youtube.integration.test.ts
+++ b/backend/src/__tests__/integration/routes/youtube.integration.test.ts
@@ -1,0 +1,182 @@
+import request from 'supertest';
+import express from 'express';
+import * as fs from 'node:fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
+
+const execFileAsync = promisify(execFile);
+
+const TEST_CONFIG = {
+  TEST_VIDEO_URL: 'https://www.youtube.com/watch?v=m3fqyXZ4k4I',
+  INVALID_URL: 'https://example.com/not-youtube',
+  POLL_INTERVAL_MS: 5000,
+  DOWNLOAD_TIMEOUT_MS: 90000,
+};
+
+type AppModules = {
+  app: express.Application;
+  videosDir: string;
+};
+
+async function isYtDlpAvailable(): Promise<boolean> {
+  try {
+    await execFileAsync('yt-dlp', ['--version']);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function createIsolatedApp(): Promise<AppModules> {
+  const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'sofathek-youtube-integration-'));
+  const videosDir = path.join(tempRoot, 'videos');
+  const tempDir = path.join(tempRoot, 'temp');
+
+  await fs.mkdir(videosDir, { recursive: true });
+  await fs.mkdir(tempDir, { recursive: true });
+
+  process.env.VIDEOS_DIR = videosDir;
+  process.env.TEMP_DIR = tempDir;
+
+  jest.resetModules();
+  jest.unmock('fs/promises');
+  jest.unmock('node:fs/promises');
+  jest.unmock('youtube-dl-exec');
+  jest.unmock('ffmpeggy');
+
+  const { default: youtubeRouter } = await import('../../../routes/youtube');
+  const { globalErrorHandler } = await import('../../../middleware/errorHandler');
+
+  const app = express();
+  app.use(express.json());
+  app.use('/api/youtube', youtubeRouter);
+  app.use(globalErrorHandler);
+
+  return {
+    app,
+    videosDir,
+  };
+}
+
+async function waitForDownloadCompletion(
+  app: express.Application,
+  queueItemId: string
+): Promise<request.Response> {
+  const start = Date.now();
+
+  while (Date.now() - start < TEST_CONFIG.DOWNLOAD_TIMEOUT_MS) {
+    await new Promise((resolve) => setTimeout(resolve, TEST_CONFIG.POLL_INTERVAL_MS));
+
+    const statusResponse = await request(app).get(`/api/youtube/download/${queueItemId}/status`);
+    const status = statusResponse.body?.data?.status as string | undefined;
+
+    if (status === 'completed') {
+      return statusResponse;
+    }
+
+    if (status === 'failed') {
+      const error = statusResponse.body?.data?.error || 'Unknown download error';
+      throw new Error(`Download failed for queue item ${queueItemId}: ${String(error)}`);
+    }
+  }
+
+  throw new Error(`Timed out waiting for queue item ${queueItemId} to complete`);
+}
+
+describe('YouTube Download Integration (Real)', () => {
+  const shouldSkipRealDownloadTests = process.env.SKIP_REAL_DOWNLOAD_TESTS === 'true';
+  const suite = shouldSkipRealDownloadTests ? describe.skip : describe;
+
+  suite('real API and download workflow', () => {
+    let app: express.Application;
+    let videosDir: string;
+
+    beforeAll(async () => {
+      if (!(await isYtDlpAvailable())) {
+        throw new Error('yt-dlp is not available in PATH. Install yt-dlp or set SKIP_REAL_DOWNLOAD_TESTS=true.');
+      }
+
+      const modules = await createIsolatedApp();
+      app = modules.app;
+      videosDir = modules.videosDir;
+    });
+
+    afterAll(async () => {
+      if (videosDir) {
+        const testRoot = path.dirname(videosDir);
+        await fs.rm(testRoot, { recursive: true, force: true });
+      }
+
+      delete process.env.VIDEOS_DIR;
+      delete process.env.TEMP_DIR;
+    });
+
+    it('downloads a real YouTube video and writes an mp4 file', async () => {
+      const initialFiles = await fs.readdir(videosDir);
+
+      const response = await request(app)
+        .post('/api/youtube/download')
+        .send({ url: TEST_CONFIG.TEST_VIDEO_URL })
+        .timeout(TEST_CONFIG.DOWNLOAD_TIMEOUT_MS);
+
+      expect(response.status).toBe(201);
+      expect(response.body.status).toBe('success');
+
+      const queueItemId = response.body.data?.queueItem?.id as string | undefined;
+      expect(queueItemId).toBeDefined();
+
+      const statusResponse = await waitForDownloadCompletion(app, queueItemId as string);
+      expect(statusResponse.status).toBe(200);
+      expect(statusResponse.body.data.status).toBe('completed');
+
+      const finalFiles = await fs.readdir(videosDir);
+      const initialMp4 = initialFiles.filter((file) => file.endsWith('.mp4'));
+      const finalMp4 = finalFiles.filter((file) => file.endsWith('.mp4'));
+
+      expect(finalMp4.length).toBeGreaterThan(initialMp4.length);
+    }, TEST_CONFIG.DOWNLOAD_TIMEOUT_MS + 30000);
+
+    it('returns 400 for a non-YouTube URL', async () => {
+      const response = await request(app)
+        .post('/api/youtube/download')
+        .send({ url: TEST_CONFIG.INVALID_URL })
+        .timeout(TEST_CONFIG.DOWNLOAD_TIMEOUT_MS);
+
+      expect(response.status).toBe(400);
+      expect(response.body.message).toContain('Invalid YouTube URL format');
+    });
+
+    it('exposes metadata on completed download status', async () => {
+      const response = await request(app)
+        .post('/api/youtube/download')
+        .send({ url: TEST_CONFIG.TEST_VIDEO_URL })
+        .timeout(TEST_CONFIG.DOWNLOAD_TIMEOUT_MS);
+
+      expect(response.status).toBe(201);
+
+      const queueItemId = response.body.data?.queueItem?.id as string | undefined;
+      expect(queueItemId).toBeDefined();
+
+      const statusResponse = await waitForDownloadCompletion(app, queueItemId as string);
+      const metadata = statusResponse.body.data?.result?.metadata;
+
+      expect(metadata).toBeDefined();
+      expect(typeof metadata.id).toBe('string');
+      expect(typeof metadata.title).toBe('string');
+      expect(metadata.title.length).toBeGreaterThan(0);
+    }, TEST_CONFIG.DOWNLOAD_TIMEOUT_MS + 30000);
+
+    it('returns live queue status fields', async () => {
+      const response = await request(app).get('/api/youtube/queue');
+
+      expect(response.status).toBe(200);
+      expect(response.body.status).toBe('success');
+      expect(response.body.data).toHaveProperty('totalItems');
+      expect(response.body.data).toHaveProperty('processing');
+      expect(response.body.data).toHaveProperty('completed');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Backend coverage for YouTube download was limited to mocked route tests, so API-level behavior with real yt-dlp execution was not being validated.

## Root Cause

All existing backend route tests for YouTube mocked services globally, which prevented any test from exercising real metadata fetch, download, and queue completion behavior.

## Changes

| File | Change |
|------|--------|
| `backend/jest.config.js` | Increased Jest timeout from `10000` to `120000` for real-network integration flow |
| `backend/src/__tests__/integration/routes/youtube.integration.test.ts` | Added real integration tests for download completion, metadata extraction, invalid URL handling, and queue status |
| `README.md` | Added backend real YouTube integration test path to test tiers |

## Testing

- [x] Type check passes (`cd backend && npm run type-check`)
- [x] Unit/integration tests pass (`cd backend && npm test`)
- [x] Lint passes (`cd backend && npm run lint`)
- [x] Manual validation completed with real download (`cd backend && npm test -- --testPathPattern=\"youtube.integration\"`)

## Validation

```bash
cd backend && npm run type-check && npm test -- --testPathPattern="youtube.integration" && npm run lint && npm test
```

## Issue

Fixes #12

---

<details>
<summary>📋 Implementation Details</summary>

### Implementation followed investigation comment

Issue comment artifact on #12 posted by `github-actions` at `2026-03-12T06:01:03Z`.

### Deviations from plan

- Added `jest.unmock(...)` and isolated temp directories in the new integration test so real download/file behavior works despite global test setup mocks.

</details>

---

_Automated implementation from investigation artifact_