### PR TITLE
Fix: real YouTube metadata diagnostics (#108)

### DIFF
--- a/backend/src/services/youTubeDownloadService.ts
+++ b/backend/src/services/youTubeDownloadService.ts
@@ -152,15 +152,22 @@ export class YouTubeDownloadService {
    * Get video metadata using yt-dlp
    */
   private async getVideoMetadata(url: string): Promise<YouTubeMetadata> {
+    let stderrOutput = '';
+
     try {
       logger.info('Fetching video metadata', { url });
 
-      const metadata = await youtubedl(url, {
+      const subprocess = youtubedl.exec(url, {
         dumpSingleJson: true,
-        noWarnings: true,
         skipDownload: true,
         noCheckCertificates: true
-      }) as any; // Type assertion for youtube-dl-exec response
+      });
+
+      subprocess.stderr?.on('data', (data) => {
+        stderrOutput += data.toString();
+      });
+
+      const metadata = await subprocess as any; // Type assertion for youtube-dl-exec response
 
       return {
         id: metadata.id || uuidv4(),
@@ -178,8 +185,13 @@ export class YouTubeDownloadService {
 
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
-      logger.error('Failed to get video metadata', { url, error: errorMessage });
-      throw new AppError(`Failed to get video metadata: ${errorMessage}`, 500);
+      const stderrMessage = stderrOutput.trim();
+      const detailedMessage = stderrMessage
+        ? `${errorMessage || 'yt-dlp metadata fetch failed'} (stderr: ${stderrMessage})`
+        : errorMessage;
+
+      logger.error('Failed to get video metadata', { url, error: detailedMessage });
+      throw new AppError(`Failed to get video metadata: ${detailedMessage}`, 500);
     }
   }
 


### PR DESCRIPTION
## Summary

Improve metadata-fetch failure diagnostics for YouTube downloads by capturing yt-dlp stderr output and surfacing it in logs/API errors.

## Root Cause

`getVideoMetadata()` only used `error.message`, which can be empty or insufficient when `youtube-dl-exec` fails due to stderr output from yt-dlp.

## Changes

| File | Change |
|------|--------|
| `backend/src/services/youTubeDownloadService.ts` | Switched metadata call to `youtubedl.exec()`, captured `stderr`, and included stderr details in error logging/AppError |

## Testing

- [x] Type check passes (`npm run type-check`)
- [x] Unit/integration tests pass (`npm test -- --testPathPattern="youtube.integration"`)
- [x] Lint passes (`npm run lint`)

## Validation

```bash
cd backend
npm run type-check && npm test -- --testPathPattern="youtube.integration" && npm run lint
```

## Issue

Fixes #108

---

<details>
<summary>📋 Implementation Details</summary>

### Implementation followed investigation comment on issue #108

### Deviations from plan

- `noWarnings: false` from the investigation plan was **not** kept because `youtube-dl-exec` converts that to invalid CLI arg `--no-no-warnings`. The fix omits `noWarnings` entirely to preserve warnings without generating invalid flags.

</details>

---

_Automated implementation from investigation artifact_