### PR TITLE
Fix: Add input validation to streaming endpoint (#112)

### DIFF
--- a/backend/src/__tests__/integration/routes/api.test.ts
+++ b/backend/src/__tests__/integration/routes/api.test.ts
@@ -138,6 +138,46 @@ describe('API Routes', () => {
       const errorMessage = response.body.error?.message || response.body.message;
       expect(errorMessage).toBe('Range not satisfiable');
     });
+
+    it('should reject path traversal attempts', async () => {
+      const response = await request(app)
+        .get('/api/stream/..%2F..%2F..%2Fetc%2Fpasswd')  // URL encoded ../../../etc/passwd
+        .expect(400);
+
+      expect(response.body.status).toBe('error');
+      const errorMessage = response.body.error?.message || response.body.message;
+      expect(errorMessage).toContain('Invalid filename');
+    });
+
+    it('should reject absolute paths', async () => {
+      const response = await request(app)
+        .get('/api/stream/%2Fetc%2Fpasswd')  // URL encoded /etc/passwd
+        .expect(400);
+
+      expect(response.body.status).toBe('error');
+      const errorMessage = response.body.error?.message || response.body.message;
+      expect(errorMessage).toContain('Invalid filename');
+    });
+
+    it('should reject non-video file extensions', async () => {
+      const response = await request(app)
+        .get('/api/stream/malicious.exe')
+        .expect(400);
+
+      expect(response.body.status).toBe('error');
+      const errorMessage = response.body.error?.message || response.body.message;
+      expect(errorMessage).toContain('Invalid file type');
+    });
+
+    it('should reject files with no extension', async () => {
+      const response = await request(app)
+        .get('/api/stream/README')
+        .expect(400);
+
+      expect(response.body.status).toBe('error');
+      const errorMessage = response.body.error?.message || response.body.message;
+      expect(errorMessage).toContain('Invalid file type');
+    });
   });
 
   describe('GET /api/thumbnails/:filename', () => {

--- a/backend/src/routes/api.ts
+++ b/backend/src/routes/api.ts
@@ -63,6 +63,18 @@ router.get('/stream/:filename', catchAsync(async (req: Request, res: Response) =
     throw new AppError('Filename parameter is required', 400);
   }
   
+  // Security: Validate filename to prevent directory traversal
+  if (filename.includes('..') || path.isAbsolute(filename)) {
+    throw new AppError('Invalid filename', 400);
+  }
+  
+  // Only allow video file extensions
+  const allowedExtensions = ['.mp4', '.webm', '.ogg', '.avi', '.mov', '.wmv', '.flv', '.mkv', '.m4v'];
+  const ext = path.extname(filename).toLowerCase();
+  if (!allowedExtensions.includes(ext)) {
+    throw new AppError('Invalid file type', 400);
+  }
+  
   const videoPath = path.join(videosDirectory, filename);
   
   logger.info(`Streaming video: ${filename}`, {
@@ -73,6 +85,13 @@ router.get('/stream/:filename', catchAsync(async (req: Request, res: Response) =
   // Verify file exists and is accessible
   if (!fs.existsSync(videoPath)) {
     throw new AppError(`Video file '${filename}' not found`, 404);
+  }
+  
+  // Security: Verify resolved path is within allowed videos directory
+  const resolvedVideoPath = path.resolve(videoPath);
+  const allowedVideosDir = path.resolve(videosDirectory);
+  if (!resolvedVideoPath.startsWith(allowedVideosDir + path.sep) && resolvedVideoPath !== allowedVideosDir) {
+    throw new AppError('Invalid path', 403);
   }
   
   // Get file stats


### PR DESCRIPTION
## Summary

The streaming endpoint lacked proper input validation for filename parameters, creating critical security vulnerabilities for path traversal attacks.

## Root Cause

The stream endpoint was implemented without security validation while the thumbnails endpoint (same file) has proper validation.

## Changes

| File | Change |
|------|--------|
| `backend/src/routes/api.ts` | Added path traversal validation, absolute path validation, video extension allowlist, and path resolution validation |
| `backend/src/__tests__/integration/routes/api.test.ts` | Added comprehensive security tests for all validation cases |

## Testing

- [x] Type check passes
- [x] Unit tests pass (17/17 API tests)
- [x] Lint passes
- [x] Manual verification: Path traversal attacks properly rejected with 400 errors

## Validation

\`\`\`bash
# Run project's validation commands
cd backend && npm run type-check && npm test -- --testPathPattern="api.test" && npm run lint
\`\`\`

## Issue

Fixes #112

---

<details>
<summary>📋 Implementation Details</summary>

### Implementation followed artifact:

Investigation comment from issue #112

### Deviations from plan:

- Fixed test cases to use URL-encoded paths (..%2F instead of ../) to properly test Express route parameter handling
- This was necessary because Express normalizes unencoded path traversal attempts before they reach our validation

</details>

---

_Automated implementation from investigation artifact_