### PR TITLE
fix: Secure thumbnail endpoint path validation to prevent directory traversal

### DIFF
--- a/backend/src/routes/api.ts
+++ b/backend/src/routes/api.ts
@@ -205,8 +205,8 @@ router.get('/thumbnails/:filename', catchAsync(async (req: Request, res: Respons
   const allowedVideosDir = path.resolve(videosDirectory);
   const allowedTempDir = path.resolve(tempDirectory, 'thumbnails');
   
-  const isInVideosDir = resolvedVideosPath.startsWith(allowedVideosDir);
-  const isInTempDir = resolvedTempPath.startsWith(allowedTempDir);
+  const isInVideosDir = resolvedVideosPath.startsWith(allowedVideosDir + path.sep) || resolvedVideosPath === allowedVideosDir;
+  const isInTempDir = resolvedTempPath.startsWith(allowedTempDir + path.sep) || resolvedTempPath === allowedTempDir;
   
   if (thumbnailPath === videosThumbPath && !isInVideosDir) {
     throw new AppError('Invalid path', 403);


### PR DESCRIPTION
## Summary
- Fixes security vulnerability in thumbnail endpoint path validation
- Prevents directory traversal attacks to sibling directories
- Applies same security pattern used in stream endpoint

## Problem
The thumbnail endpoint had weak path validation that could allow access to sibling directories. For example, if the allowed directory is `/data/videos`, a request for `/data/videos-backup` would be incorrectly allowed because the path starts with `/data/videos`.

## Solution
Added proper path boundary validation using `+ path.sep` pattern:
- Changed from: `resolvedVideosPath.startsWith(allowedVideosDir)`
- Changed to: `resolvedVideosPath.startsWith(allowedVideosDir + path.sep) || resolvedVideosPath === allowedVideosDir`

This ensures only exact directory matches or subdirectories are allowed, preventing access to sibling directories.

## Testing
- ✅ All existing tests pass (144 tests)
- ✅ TypeScript compilation passes
- ✅ Lint checks pass
- ✅ Build validation passes

## Related
- Closes #120
- Related to PR #117 (which incorrectly targets the stream endpoint instead of thumbnail endpoint)