### PR TITLE
Fix: Add path boundary validation to thumbnail endpoint (#123)

### DIFF
--- a/backend/src/routes/api.ts
+++ b/backend/src/routes/api.ts
@@ -205,8 +205,8 @@ router.get('/thumbnails/:filename', catchAsync(async (req: Request, res: Respons
   const allowedVideosDir = path.resolve(videosDirectory);
   const allowedTempDir = path.resolve(tempDirectory, 'thumbnails');
   
-  const isInVideosDir = resolvedVideosPath.startsWith(allowedVideosDir);
-  const isInTempDir = resolvedTempPath.startsWith(allowedTempDir);
+  const isInVideosDir = resolvedVideosPath.startsWith(allowedVideosDir + path.sep) || resolvedVideosPath === allowedVideosDir;
+  const isInTempDir = resolvedTempPath.startsWith(allowedTempDir + path.sep) || resolvedTempPath === allowedTempDir;
   
   if (thumbnailPath === videosThumbPath && !isInVideosDir) {
     throw new AppError('Invalid path', 403);


### PR DESCRIPTION
## Summary

The thumbnail endpoint was missing proper directory boundary validation, allowing potential directory traversal attacks. This fix adds the secure path validation pattern already used in the video streaming endpoint.

## Root Cause

The path validation at `backend/src/routes/api.ts:208-209` was using only `startsWith(allowedVideosDir)` without `+ path.sep`, which could allow access to sibling directories like `/data/videos-backup` when the videos directory is `/data/videos`.

## Changes

| File | Change |
|------|--------|
| `backend/src/routes/api.ts` | Add `+ path.sep` path boundary check to thumbnail endpoint validation |

## Testing

- [x] Type check passes
- [x] Unit tests pass  
- [x] Lint passes
- [x] All 26 thumbnail security tests pass, including directory traversal prevention

## Validation

```bash
# Run project validation commands
cd backend && npm run type-check && npm test -- --testPathPattern=thumbnails && npm run lint
```

## Issue

Fixes #123

---

<details>
<summary>📋 Implementation Details</summary>

### Implementation followed artifact:

Investigation comment from issue #123 provided complete implementation plan.

### Deviations from plan:

None - implementation exactly matches the artifact specification.

</details>

---

_Automated implementation from investigation artifact_