### PR TITLE
Fix: Add comprehensive tests for FFmpeg event listener cleanup (#155)

### DIFF
--- a/backend/src/__tests__/unit/services/thumbnailService.test.ts
+++ b/backend/src/__tests__/unit/services/thumbnailService.test.ts
@@ -17,10 +17,16 @@ jest.mock('fs/promises', () => ({
 
 const mockFFmpeggyRun = jest.fn();
 const mockFFmpeggyDone = jest.fn();
+const mockFFmpeggyOn = jest.fn();
+const mockFFmpeggyOff = jest.fn();
+const mockFFmpeggyRemoveListener = jest.fn();
 jest.mock('ffmpeggy', () => ({
   FFmpeggy: jest.fn().mockImplementation(() => ({
     run: mockFFmpeggyRun,
-    done: mockFFmpeggyDone
+    done: mockFFmpeggyDone,
+    on: mockFFmpeggyOn,
+    off: mockFFmpeggyOff,
+    removeListener: mockFFmpeggyRemoveListener
   }))
 }));
 
@@ -169,6 +175,114 @@ describe('ThumbnailService - Real FFmpeg Integration', () => {
       // Expected if test video doesn't exist
       expect(error).toBeDefined();
     }
+  });
+});
+
+describe('ThumbnailService - generateThumbnailWithProgress', () => {
+  let service: ThumbnailService;
+
+  beforeEach(() => {
+    service = new ThumbnailService('/test', '/test');
+    jest.clearAllMocks();
+    
+    // Reset fs mocks
+    mockAccess.mockResolvedValue(undefined);
+    mockMkdir.mockResolvedValue(undefined);
+    
+    // Reset FFmpeggy mocks
+    mockFFmpeggyRun.mockResolvedValue(undefined);
+    mockFFmpeggyDone.mockResolvedValue(undefined);
+    mockFFmpeggyOn.mockReturnValue(undefined);
+    mockFFmpeggyRemoveListener.mockReturnValue(undefined);
+  });
+
+  it('should generate thumbnail with progress callback and clean up event listeners', async () => {
+    // Mock progress callback
+    const progressCallback = jest.fn();
+
+    // Execute the method
+    await service.generateThumbnailWithProgress('/test/video.mp4', progressCallback);
+
+    // Verify event listeners were set up
+    expect(mockFFmpeggyOn).toHaveBeenCalledWith('progress', expect.any(Function));
+    expect(mockFFmpeggyOn).toHaveBeenCalledWith('error', expect.any(Function));
+    
+    // Verify event listeners were cleaned up
+    expect(mockFFmpeggyRemoveListener).toHaveBeenCalledWith('progress', expect.any(Function));
+    expect(mockFFmpeggyRemoveListener).toHaveBeenCalledWith('error', expect.any(Function));
+  });
+
+  it('should generate thumbnail without progress callback and still clean up error listener', async () => {
+    await service.generateThumbnailWithProgress('/test/video.mp4');
+    
+    // Verify only error listener was set up (no progress listener)
+    expect(mockFFmpeggyOn).not.toHaveBeenCalledWith('progress', expect.any(Function));
+    expect(mockFFmpeggyOn).toHaveBeenCalledWith('error', expect.any(Function));
+    
+    // Verify error listener was cleaned up
+    expect(mockFFmpeggyRemoveListener).toHaveBeenCalledWith('error', expect.any(Function));
+    expect(mockFFmpeggyRemoveListener).toHaveBeenCalledTimes(1); // Only error handler
+  });
+
+  it('should clean up event listeners even when FFmpeg fails', async () => {
+    // Mock FFmpeggy to fail
+    mockFFmpeggyRun.mockRejectedValue(new Error('FFmpeg failed'));
+    
+    const progressCallback = jest.fn();
+    
+    try {
+      await service.generateThumbnailWithProgress('/test/video.mp4', progressCallback);
+    } catch (error) {
+      // Expected to fail
+    }
+    
+    // Verify event listeners were still cleaned up despite the error
+    expect(mockFFmpeggyRemoveListener).toHaveBeenCalledWith('progress', expect.any(Function));
+    expect(mockFFmpeggyRemoveListener).toHaveBeenCalledWith('error', expect.any(Function));
+  });
+
+  it('should clean up event listeners even when thumbnail file verification fails', async () => {
+    // Mock file access to fail (thumbnail not created)
+    mockAccess.mockRejectedValue(new Error('File not found'));
+    
+    const progressCallback = jest.fn();
+    
+    try {
+      await service.generateThumbnailWithProgress('/test/video.mp4', progressCallback);
+    } catch (error) {
+      // Expected to fail
+    }
+    
+    // Verify event listeners were cleaned up despite verification failure
+    expect(mockFFmpeggyRemoveListener).toHaveBeenCalledWith('progress', expect.any(Function));
+    expect(mockFFmpeggyRemoveListener).toHaveBeenCalledWith('error', expect.any(Function));
+  });
+
+  it('should handle progress events correctly', async () => {
+    const progressCallback = jest.fn();
+    
+    // Track the progress handler for manual testing
+    let capturedProgressHandler: any;
+    mockFFmpeggyOn.mockImplementation((event: string, handler: any) => {
+      if (event === 'progress') {
+        capturedProgressHandler = handler;
+      }
+    });
+
+    await service.generateThumbnailWithProgress('/test/video.mp4', progressCallback);
+    
+    // Manually trigger the captured progress handler to test the logic
+    expect(capturedProgressHandler).toBeDefined();
+    
+    capturedProgressHandler({ percent: 25.7 }); // Should round to 26
+    capturedProgressHandler({ percent: 50.2 }); // Should round to 50  
+    capturedProgressHandler({ percent: 75.9 }); // Should round to 76
+    capturedProgressHandler({}); // Should be ignored (no percent)
+    
+    expect(progressCallback).toHaveBeenCalledWith(26);
+    expect(progressCallback).toHaveBeenCalledWith(50);
+    expect(progressCallback).toHaveBeenCalledWith(76);
+    expect(progressCallback).toHaveBeenCalledTimes(3);
   });
 });
 


### PR DESCRIPTION
## Summary

The main FFmpeg event listener cleanup functionality was already implemented in `thumbnailService.generateThumbnailWithProgress`, but comprehensive tests were missing to verify the event listener management works correctly. This PR completes the issue by adding the missing test coverage.

## Root Cause

Event listeners added in `generateThumbnailWithProgress` method at lines 143 (`progress` event) and 156 (`error` event) needed proper test coverage to ensure they are correctly cleaned up to prevent memory leaks.

## Changes

| File | Change |
|------|--------|
| `backend/src/__tests__/unit/services/thumbnailService.test.ts` | Added FFmpeggy event listener mocks (.on, .off, .removeListener) |
| `backend/src/__tests__/unit/services/thumbnailService.test.ts` | Added comprehensive test suite for generateThumbnailWithProgress method |

## Testing

- [x] Type check passes
- [x] Unit tests pass (16 total, 1 skipped, 15 passed)
- [x] Lint passes
- [x] Tests verify event listeners are properly set up and cleaned up
- [x] Tests cover error scenarios and progress callback handling
- [x] Tests ensure cleanup happens even when FFmpeg or file verification fails

## Validation

```bash
# Run project's validation commands
cd backend && npm run type-check && npm test -- --testPathPattern=thumbnailService && npm run lint
```

## Issue

Fixes #155

---

<details>
<summary>📋 Implementation Details</summary>

### Implementation followed artifact:

Investigation comment from issue #155

### Deviations from plan:

The main event listener cleanup code was already implemented in a previous commit (45835c7). This PR focused on completing the missing test coverage as specified in the artifact's Step 3.

</details>

---

_Automated implementation from investigation artifact_