### PR TITLE
Fix: RateLimiter setInterval causes Jest to hang indefinitely (#153)

### DIFF
--- a/backend/src/__tests__/integration/routes/api.test.ts
+++ b/backend/src/__tests__/integration/routes/api.test.ts
@@ -15,6 +15,9 @@ jest.mock('../../../config', () => ({
   }
 }));
 
+import { cleanupAllRateLimiters } from '../../../middleware/rateLimiter';
+import { downloadRateLimiter } from '../../../routes/youtube';
+
 import { apiRouter } from '../../../routes/api';
 import { globalErrorHandler } from '../../../middleware/errorHandler';
 
@@ -372,4 +375,11 @@ describe('API Routes', () => {
       expect(response.headers['accept-ranges']).toBe('bytes');
     });
   });
+});
+
+afterAll(() => {
+  // Clean up the rate limiter created by youtube routes
+  downloadRateLimiter.close();
+  // Also clean up any others via the global cleanup
+  cleanupAllRateLimiters();
 });


### PR DESCRIPTION
## Summary

Fixed Jest hanging indefinitely after test completion by properly cleaning up RateLimiter instances that create unmanaged setInterval timers.

## Root Cause

The RateLimiter class creates a `setInterval` in the constructor (rateLimiter.ts:22-31) to periodically clean up expired entries. This interval keeps the Node.js event loop running, preventing Jest from exiting naturally after tests complete. The test file `api.test.ts` imports routes that create global RateLimiter instances, but had no cleanup mechanism.

## Changes

| File | Change |
|------|--------|
| `backend/src/__tests__/integration/routes/api.test.ts` | Added afterAll hook with cleanup |

## Testing

- [x] Type check passes
- [x] Unit tests pass (176 passed)  
- [x] Lint passes
- [x] Integration test `api.test.ts` completes successfully (19 tests passed)

## Validation

```bash
# Run the specific test to verify fix
cd backend && npm test -- src/__tests__/integration/routes/api.test.ts
```

## Issue

Fixes #153

---

<details>
<summary>📋 Implementation Details</summary>

### Implementation followed artifact:

Investigation comment on issue #153 provided the exact implementation plan

### Deviations from plan:

- Added explicit `downloadRateLimiter.close()` call in addition to `cleanupAllRateLimiters()` for more thorough cleanup
- Moved afterAll hook placement to ensure proper execution scope

</details>

---

_Automated implementation from investigation artifact_