### PR TITLE
Fix: Misleading parameter name in fileValidation utility (#160)

### DIFF
--- a/backend/src/__tests__/unit/utils/fileValidation.test.ts
+++ b/backend/src/__tests__/unit/utils/fileValidation.test.ts
@@ -1,0 +1,35 @@
+import { validatePathInDirectory } from '../../../utils/fileValidation';
+
+describe('fileValidation', () => {
+  describe('validatePathInDirectory', () => {
+    const allowedDir = '/allowed/dir';
+
+    it('should allow path within allowed directory', () => {
+      expect(() => validatePathInDirectory('/allowed/dir/file.txt', allowedDir)).not.toThrow();
+    });
+
+    it('should allow exact allowed directory', () => {
+      expect(() => validatePathInDirectory(allowedDir, allowedDir)).not.toThrow();
+    });
+
+    it('should reject path outside allowed directory', () => {
+      expect(() => validatePathInDirectory('/other/dir/file.txt', allowedDir)).toThrow('Invalid path');
+    });
+
+    it('should reject path with directory traversal', () => {
+      expect(() => validatePathInDirectory('/allowed/dir/../../../etc/passwd', allowedDir)).toThrow('Invalid path');
+    });
+
+    it('should normalize paths before validation', () => {
+      expect(() => validatePathInDirectory('/allowed/dir/./subdir/../file.txt', allowedDir)).not.toThrow();
+    });
+
+    it('should handle relative paths by resolving them', () => {
+      // When we pass a relative path, it gets resolved relative to cwd
+      // This test ensures the function handles this gracefully
+      const relativePath = 'subdir/file.txt';
+      const workingDir = process.cwd();
+      expect(() => validatePathInDirectory(relativePath, workingDir)).not.toThrow();
+    });
+  });
+});

--- a/backend/src/routes/api.ts
+++ b/backend/src/routes/api.ts
@@ -95,12 +95,9 @@ router.get('/stream/:filename', catchAsync(async (req: Request, res: Response) =
     throw new AppError('Unable to access video file', 500);
   }
   
-  // Security: Verify resolved path is within allowed directory
-  const resolvedVideoPath = path.resolve(videoPath);
+  // Security: Validate path is within allowed directory (function handles normalization internally)
   const allowedVideosDir = path.resolve(videosDirectory);
-  
-  // Validate path is in allowed directory
-  validatePathInDirectory(resolvedVideoPath, allowedVideosDir);
+  validatePathInDirectory(videoPath, allowedVideosDir);
   
   // Get file stats
   const stat = fs.statSync(videoPath);
@@ -207,11 +204,9 @@ router.get('/thumbnails/:filename', catchAsync(async (req: Request, res: Respons
   
   // Validate path is in allowed directory based on which location was used
   if (thumbnailPath === videosThumbPath) {
-    const resolvedPath = path.resolve(thumbnailPath);
-    validatePathInDirectory(resolvedPath, allowedVideosDir);
+    validatePathInDirectory(thumbnailPath, allowedVideosDir);
   } else if (thumbnailPath === tempThumbPath) {
-    const resolvedPath = path.resolve(thumbnailPath);
-    validatePathInDirectory(resolvedPath, allowedTempDir);
+    validatePathInDirectory(thumbnailPath, allowedTempDir);
   }
   
   if (!stat || stat.size > MAX_THUMBNAIL_SIZE) {

--- a/backend/src/utils/fileValidation.ts
+++ b/backend/src/utils/fileValidation.ts
@@ -26,8 +26,18 @@ export function validateImageFilename(filename: string): void {
   validateFilename(filename, IMAGE_EXTENSIONS);
 }
 
-export function validatePathInDirectory(resolvedPath: string, allowedDir: string): void {
-  if (!resolvedPath.startsWith(allowedDir + path.sep) && resolvedPath !== allowedDir) {
+/**
+ * Validates that a target path is within an allowed directory.
+ * Internally normalizes the targetPath using path.resolve() for consistent behavior.
+ * 
+ * @param targetPath - The file path to validate (will be normalized internally)
+ * @param allowedDir - The allowed directory path (should be pre-resolved)
+ */
+export function validatePathInDirectory(targetPath: string, allowedDir: string): void {
+  const resolvedPath = path.resolve(targetPath);
+  const resolvedDir = path.resolve(allowedDir);
+  
+  if (!resolvedPath.startsWith(resolvedDir + path.sep) && resolvedPath !== resolvedDir) {
     throw new AppError('Invalid path', 403);
   }
 }


### PR DESCRIPTION
## Summary

The resolvedPath parameter in validatePathInDirectory function was misleadingly named since callers had to pre-resolve paths, creating inconsistent behavior if some callers forgot to do this.

## Root Cause

The current implementation required callers to pre-resolve paths with path.resolve() before passing them to the function, creating inconsistent behavior and a misleading API interface. The parameter name suggested paths were already resolved, but the function didn't handle normalization internally.

## Changes

| File | Change |
|------|--------|
| `backend/src/utils/fileValidation.ts` | Renamed parameter from resolvedPath to targetPath and added internal path normalization with JSDoc |
| `backend/src/routes/api.ts` | Removed redundant pre-resolution calls in video streaming endpoint |
| `backend/src/routes/api.ts` | Removed redundant pre-resolution calls in thumbnail validation paths |
| `backend/src/__tests__/unit/utils/fileValidation.test.ts` | Added comprehensive unit tests for validatePathInDirectory function |

## Testing

- [x] Type check passes
- [x] Unit tests pass (6 new tests for validatePathInDirectory)
- [x] Integration tests pass (all existing tests still pass)
- [x] Lint passes
- [x] All validation commands succeed

## Validation

```bash
cd backend && npm run type-check && npm test -- --testPathPattern=fileValidation && npm run lint
```

## Issue

Fixes #160

---

<details>
<summary>📋 Implementation Details</summary>

### Implementation followed artifact:

Issue #160 investigation comment from GHAR system

### Deviations from plan:

- Fixed one test case for relative path handling to match actual behavior of path.resolve()
- All other changes implemented exactly as specified in the artifact

</details>

---

_Automated implementation from investigation artifact_