### PR TITLE
Fix: E2E tests stuck during yt-dlp installation in CI (#166)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,8 +121,9 @@ jobs:
 
       - name: Install yt-dlp system binary
         run: |
-          sudo apt-get update
-          sudo apt-get install -y yt-dlp
+          pip install --upgrade pip
+          pip install yt-dlp
+        timeout-minutes: 5
         
       - name: Install Playwright browsers
         run: make playwright-install
@@ -255,8 +256,9 @@ jobs:
 
       - name: Install yt-dlp system binary
         run: |
-          sudo apt-get update
-          sudo apt-get install -y yt-dlp
+          pip install --upgrade pip
+          pip install yt-dlp
+        timeout-minutes: 5
         
       - name: Build for production
         run: make build


### PR DESCRIPTION
## Summary

E2E and Integration tests in the CI pipeline are getting stuck during the 'Install yt-dlp system binary' step, preventing PR merges due to unreliable apt-get update in GitHub Actions runners.

## Root Cause

The CI uses `sudo apt-get update && sudo apt-get install -y yt-dlp` which can hang indefinitely due to network issues or slow package mirrors in GitHub Actions runners. No timeout is set on the apt-get commands, causing the job to hang.

## Changes

| File | Change |
|------|--------|
| `.github/workflows/ci.yml` | Replace apt-get with pip for yt-dlp installation in E2E tests (lines 122-125) |
| `.github/workflows/ci.yml` | Replace apt-get with pip for yt-dlp installation in Integration tests (lines 256-259) |
| `.github/workflows/ci.yml` | Add timeout-minutes: 5 to prevent hanging |

## Testing

- [x] Type check passes
- [x] Unit tests pass (207 backend tests)
- [x] Frontend tests pass (143 tests) 
- [x] Lint passes
- [x] Build validation passes
- [x] Pre-commit and pre-push hooks pass

## Validation

```bash
# Run project's validation commands
npm run type-check && npm run test && make lint
```

## Issue

Fixes #166

---

<details>
<summary>📋 Implementation Details</summary>

### Implementation followed artifact:

Issue #166 investigation comment by github-actions bot

### Changes Applied:

**Before:**
```yaml
- name: Install yt-dlp system binary
  run: |
    sudo apt-get update
    sudo apt-get install -y yt-dlp
```

**After:**
```yaml
- name: Install yt-dlp system binary
  run: |
    pip install --upgrade pip
    pip install yt-dlp
  timeout-minutes: 5
```

### Deviations from plan:

None - followed the artifact's implementation plan exactly

</details>

---

_Automated implementation from investigation artifact_