### PR TITLE
Fix: Download Queue Cancel Functionality Returns 400 Bad Request Errors (#169)

### DIFF
--- a/backend/src/__tests__/integration/routes/youtube.test.ts
+++ b/backend/src/__tests__/integration/routes/youtube.test.ts
@@ -235,7 +235,7 @@ describe('YouTube Routes', () => {
 
   describe('DELETE /api/youtube/download/:id', () => {
     it('should successfully cancel download', async () => {
-      mockDownloadQueueService.cancelDownload.mockResolvedValue(true);
+      mockDownloadQueueService.cancelDownload.mockResolvedValue({ success: true });
 
       const response = await request(app)
         .delete('/api/youtube/download/test-id');
@@ -246,15 +246,26 @@ describe('YouTube Routes', () => {
       expect(mockDownloadQueueService.cancelDownload).toHaveBeenCalledWith('test-id');
     });
 
-    it('should return 400 if cancel fails', async () => {
-      mockDownloadQueueService.cancelDownload.mockResolvedValue(false);
+    it('should return 404 if download not found', async () => {
+      mockDownloadQueueService.cancelDownload.mockResolvedValue({ success: false, reason: 'not_found' });
 
       const response = await request(app)
         .delete('/api/youtube/download/test-id');
 
-      expect(response.status).toBe(400);
+      expect(response.status).toBe(404);
       expect(response.body).toHaveProperty('message');
-      expect(response.body.message).toContain('Could not cancel download');
+      expect(response.body.message).toContain('not found in queue');
+    });
+
+    it('should return 409 if download already completed', async () => {
+      mockDownloadQueueService.cancelDownload.mockResolvedValue({ success: false, reason: 'already_completed' });
+
+      const response = await request(app)
+        .delete('/api/youtube/download/test-id');
+
+      expect(response.status).toBe(409);
+      expect(response.body).toHaveProperty('message');
+      expect(response.body.message).toContain('already completed');
     });
   });
 

--- a/backend/src/__tests__/unit/services/downloadQueueService.test.ts
+++ b/backend/src/__tests__/unit/services/downloadQueueService.test.ts
@@ -115,12 +115,13 @@ describe('DownloadQueueService', () => {
       const queueItem = await service.addToQueue(request);
       const result = await service.cancelDownload(queueItem.id);
 
-      expect(result).toBe(true);
+      expect(result.success).toBe(true);
     });
 
     it('should return false for non-existent download', async () => {
       const result = await service.cancelDownload('non-existent-id');
-      expect(result).toBe(false);
+      expect(result.success).toBe(false);
+      expect(result.reason).toBe('not_found');
     });
 
     it('should return false when canceling already completed download', async () => {
@@ -139,7 +140,8 @@ describe('DownloadQueueService', () => {
       }
       
       const result = await service.cancelDownload(queueItem.id);
-      expect(result).toBe(false);
+      expect(result.success).toBe(false);
+      expect(result.reason).toBe('already_completed');
     });
   });
 

--- a/backend/src/routes/youtube.ts
+++ b/backend/src/routes/youtube.ts
@@ -142,10 +142,26 @@ router.delete('/download/:id', catchAsync(async (req: Request, res: Response) =>
 
   logger.info('Cancel download request', { queueItemId: id });
   
-  const cancelled = await downloadQueueService.cancelDownload(id);
+  const result = await downloadQueueService.cancelDownload(id);
   
-  if (!cancelled) {
-    throw new AppError(`Could not cancel download with ID '${id}'. It may not exist or already be completed.`, 400);
+  if (!result.success) {
+    // Provide specific error messages based on reason
+    if (result.reason === 'not_found') {
+      throw new AppError(`Download with ID '${id}' not found in queue.`, 404);
+    } else if (result.reason === 'already_completed') {
+      throw new AppError(`Cannot cancel download '${id}' - it has already completed.`, 409);
+    } else if (result.reason === 'already_cancelled') {
+      // Return success instead of error - already cancelled is success
+      res.json({
+        status: 'success',
+        data: {
+          message: 'Download was already cancelled',
+          queueItemId: id
+        }
+      });
+      return;
+    }
+    throw new AppError(`Could not cancel download with ID '${id}': ${result.reason}`, 400);
   }
   
   logger.info('Download cancelled successfully', { queueItemId: id });

--- a/backend/src/services/downloadQueueService.ts
+++ b/backend/src/services/downloadQueueService.ts
@@ -8,6 +8,11 @@ import { YouTubeDownloadService } from './youTubeDownloadService';
 import { loadQueue, saveQueue } from './queuePersistence';
 import { processQueue } from './queueScheduler';
 
+interface CancelResult {
+  success: boolean;
+  reason?: 'not_found' | 'already_completed' | 'already_cancelled' | 'error';
+}
+
 /**
  * Queue management for YouTube download operations
  */
@@ -110,25 +115,36 @@ export class DownloadQueueService {
   /**
    * Cancel download by queue item ID
    */
-  async cancelDownload(queueItemId: string): Promise<boolean> {
+  async cancelDownload(queueItemId: string): Promise<CancelResult> {
     try {
       const itemIndex = this.queue.findIndex(item => item.id === queueItemId);
       
       if (itemIndex === -1) {
         logger.warn('Queue item not found for cancellation', { queueItemId });
-        return false;
+        return { success: false, reason: 'not_found' };
       }
 
       const item = this.queue[itemIndex];
       
       if (!item) {
         logger.warn('Queue item is undefined', { queueItemId, itemIndex });
-        return false;
+        return { success: false, reason: 'not_found' };
       }
       
       if (item.status === 'completed') {
-        logger.warn('Cannot cancel completed download', { queueItemId });
-        return false;
+        logger.warn('Cannot cancel completed download', { queueItemId, status: item.status });
+        return { success: false, reason: 'already_completed' };
+      }
+
+      if (item.status === 'cancelled') {
+        logger.info('Download already cancelled', { queueItemId, status: item.status });
+        return { success: true, reason: 'already_cancelled' };
+      }
+
+      // Allow cancellation of 'pending' and 'processing' items
+      if (item.status !== 'pending' && item.status !== 'processing') {
+        logger.warn('Cannot cancel download with status', { queueItemId, status: item.status });
+        return { success: false, reason: 'error' };
       }
 
       // Update item status
@@ -139,14 +155,14 @@ export class DownloadQueueService {
       await this.saveQueue();
 
       logger.info('Download cancelled', { queueItemId });
-      return true;
+      return { success: true };
 
     } catch (error) {
       logger.error('Failed to cancel download', {
         queueItemId,
         error: getErrorMessage(error)
       });
-      return false;
+      return { success: false, reason: 'error' };
     }
   }
 

--- a/frontend/src/services/youtube.ts
+++ b/frontend/src/services/youtube.ts
@@ -123,7 +123,7 @@ export async function getDownloadStatus(itemId: string): Promise<QueueItem> {
 
 /**
  * Cancel a download
- * DELETE /api/youtube/cancel/:id
+ * DELETE /api/youtube/download/:id
  */
 export async function cancelDownload(itemId: string): Promise<{ message: string; queueItemId: string }> {
   const response = await youtubeApiFetch<{ message: string; queueItemId: string }>(`/youtube/download/${encodeURIComponent(itemId)}`, {
@@ -131,7 +131,19 @@ export async function cancelDownload(itemId: string): Promise<{ message: string;
   });
   
   if (response.status !== 'success' || !response.data) {
-    throw new ApiError(response.message || `Failed to cancel download '${itemId}'`);
+    const errorMessage = response.message || `Failed to cancel download '${itemId}'`;
+    
+    // Provide user-friendly messages for specific error cases
+    if (errorMessage.includes('not found') || errorMessage.includes('404')) {
+      throw new ApiError('This download no longer exists in the queue. It may have been removed.', 404);
+    } else if (errorMessage.includes('already completed') || errorMessage.includes('409')) {
+      throw new ApiError('This download has already completed and cannot be cancelled.', 409);
+    } else if (errorMessage.includes('already cancelled')) {
+      // This is actually OK - the item is cancelled
+      return { message: 'Download was already cancelled', queueItemId: itemId };
+    }
+    
+    throw new ApiError(errorMessage, 400);
   }
   
   return response.data;

--- a/frontend/tests/youtube-download/cancel-error.spec.ts
+++ b/frontend/tests/youtube-download/cancel-error.spec.ts
@@ -88,5 +88,62 @@ test.describe('YouTube Download - Full Workflow', () => {
       await helpers.form.submitDownloadForm(MOCK_YOUTUBE_URLS.VALID_WATCH);
       await helpers.form.expectFormError(customError);
     });
+
+    test('should handle 404 not found error gracefully', async ({ page }) => {
+      await helpers.mockAPI.mockQueueStatus(MOCK_QUEUE_STATUS.SINGLE_PENDING);
+      
+      // Mock 404 response for cancel
+      await page.route('**/api/youtube/download/*', async route => {
+        if (route.request().method() === 'DELETE') {
+          await route.fulfill({
+            status: 404,
+            contentType: 'application/json',
+            body: JSON.stringify({ 
+              status: 'error', 
+              message: 'Download with ID \'test-id\' not found in queue.' 
+            })
+          });
+        } else {
+          await route.continue();
+        }
+      });
+      
+      await helpers.timing.waitForQueuePoll();
+      await helpers.queue.expectQueueItem(MOCK_QUEUE_ITEMS.PENDING.id, 'pending');
+      
+      // Click cancel and expect error toast
+      await helpers.queue.cancelDownload(MOCK_QUEUE_ITEMS.PENDING.id);
+      
+      // Should show user-friendly error
+      await expect(page.locator('text=This download no longer exists')).toBeVisible();
+    });
+
+    test('should handle 409 already completed error gracefully', async ({ page }) => {
+      await helpers.mockAPI.mockQueueStatus(MOCK_QUEUE_STATUS.SINGLE_PROCESSING);
+      
+      // Mock 409 response for cancel
+      await page.route('**/api/youtube/download/*', async route => {
+        if (route.request().method() === 'DELETE') {
+          await route.fulfill({
+            status: 409,
+            contentType: 'application/json',
+            body: JSON.stringify({ 
+              status: 'error', 
+              message: 'Cannot cancel download - it has already completed.' 
+            })
+          });
+        } else {
+          await route.continue();
+        }
+      });
+      
+      await helpers.timing.waitForQueuePoll();
+      
+      // Click cancel and expect appropriate error
+      await helpers.queue.cancelDownload(MOCK_QUEUE_ITEMS.PROCESSING.id);
+      
+      // Should show user-friendly message about completed download
+      await expect(page.locator('text=already completed')).toBeVisible();
+    });
   });
 });


### PR DESCRIPTION
## Summary

When users attempted to cancel downloads from the download queue, the application returned 400 Bad Request errors. The root cause was that the backend's `cancelDownload` method returned a boolean `false` when downloads couldn't be cancelled (not found or already completed), leading to generic 400 errors instead of specific, user-friendly error messages.

## Root Cause

The 400 error occurs when `downloadQueueService.cancelDownload(id)` returns `false` at `backend/src/routes/youtube.ts:147-148`. The service returns `false` when the item cannot be cancelled (not found or already completed), but the route handler doesn't distinguish between different failure reasons.

## Changes

| File | Change |
|------|--------|
| `backend/src/services/downloadQueueService.ts` | Updated cancelDownload to return detailed CancelResult instead of boolean |
| `backend/src/routes/youtube.ts` | Improved error handling with specific HTTP status codes (404, 409) |
| `frontend/src/services/youtube.ts` | Enhanced error handling with user-friendly messages |
| `frontend/tests/youtube-download/cancel-error.spec.ts` | Added E2E tests for 404/409 error scenarios |
| Unit/Integration tests | Updated to work with new CancelResult return type |

## Testing

- [x] Type check passes
- [x] Unit tests pass  
- [x] Integration tests pass
- [x] Lint passes
- [x] E2E tests for error scenarios added

## Validation

```bash
# Backend validation
cd backend && npm run type-check && npm test && npm run lint

# Frontend validation  
cd frontend && npm run type-check && npm test && npm run lint
```

## Issue

Fixes #169

---

<details>
<summary>📋 Implementation Details</summary>

### Implementation followed artifact:

Investigation comment in issue #169

### Deviations from plan:

None - implementation followed the artifact exactly as specified.

### Error handling improvements:

- **404 Not Found**: When download item doesn't exist in queue
- **409 Conflict**: When download has already completed  
- **200 Success**: When download was already cancelled (idempotent operation)
- **200 Success**: When download cancelled successfully

</details>

---

_Automated implementation from investigation artifact_