### PR TITLE
Fix: make start should reliably start backend without downtime (#176)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,9 +15,11 @@ install: ## Install all dependencies
 	@cd backend && npm install
 
 build: ## Build frontend and backend
-	@echo "🔨 Building..."
-	@cd backend && npm run build
-	@cd frontend && npm run build
+	@echo "🔨 Building backend..."
+	@cd backend && npm run build || (echo "❌ Backend build failed" && exit 1)
+	@echo "🔨 Building frontend..."
+	@cd frontend && npm run build || (echo "❌ Frontend build failed" && exit 1)
+	@echo "✅ Build completed successfully"
 
 # Playwright E2E testing targets
 playwright-install: ## Install Playwright browsers and dependencies
@@ -74,20 +76,30 @@ dev: ## Start development servers (backend:3010, frontend:5183)
 
 start: build ## Start production servers
 	@echo "🚀 Starting production servers..."
+	@echo "Backend: http://localhost:3010 | Frontend: http://localhost:4173"
 	@echo "🧹 Cleaning up any existing processes..."
-	@lsof -ti:3010 2>/dev/null | xargs -r kill -TERM 2>/dev/null; lsof -ti:5183 2>/dev/null | xargs -r kill -TERM 2>/dev/null; sleep 0.5; lsof -ti:3010,5183 2>/dev/null | xargs -r kill -KILL 2>/dev/null; pkill -f "PORT=3010\|python3.*http.server 5183" 2>/dev/null || true
-	@trap 'kill %1 %2 2>/dev/null; exit 0' INT; \
-	(cd backend && PORT=3010 npm start) & \
-	sleep 3 && \
-	(cd frontend && python3 -m http.server 5183 --directory dist) & \
-	wait
+	@lsof -ti:3010 2>/dev/null | xargs -r kill -TERM 2>/dev/null; lsof -ti:4173 2>/dev/null | xargs -r kill -TERM 2>/dev/null; sleep 0.5; lsof -ti:3010,4173 2>/dev/null | xargs -r kill -KILL 2>/dev/null; pkill -f "PORT=3010\|npm.*preview.*4173" 2>/dev/null || true
+	@echo "Starting backend..."
+	@(cd backend && PORT=3010 npm start) &
+	@sleep 1 && ./scripts/wait-for-it.sh http://localhost:3010/health 30 || (echo "❌ Backend failed to start - check logs" && exit 1)
+	@echo "✅ Backend started successfully"
+	@echo "Starting frontend..."
+	@(cd frontend && npm run preview -- --port 4173 --host) &
+	@sleep 1 && ./scripts/wait-for-it.sh http://localhost:4173 10 || (echo "❌ Frontend failed to start" && exit 1)
+	@echo "✅ Frontend started successfully"
+	@echo ""
+	@echo "🎉 All services started!"
+	@echo "   Backend: http://localhost:3010"
+	@echo "   Frontend: http://localhost:4173"
+	@echo ""
+	@echo "Press Ctrl+C to stop all servers"
+	@trap 'kill %1 %2 2>/dev/null; exit 0' INT; wait
 
 stop: ## Stop all servers and clean up ports
 	@echo "🛑 Stopping servers..."
-	@bash -c 'for port in 3010 5183; do pids=$$(lsof -ti:$$port 2>/dev/null || true); if [ -n "$$pids" ]; then echo "  Killing processes on port $$port: $$pids"; kill -TERM $$pids 2>/dev/null || true; sleep 0.5; kill -KILL $$pids 2>/dev/null || true; fi; done'
+	@bash -c 'for port in 3010 4173; do pids=$$(lsof -ti:$$port 2>/dev/null || true); if [ -n "$$pids" ]; then echo "  Killing processes on port $$port: $$pids"; kill -TERM $$pids 2>/dev/null || true; sleep 0.5; kill -KILL $$pids 2>/dev/null || true; fi; done'
 	@pkill -f "PORT=3010" 2>/dev/null || true
-	@pkill -f "python3 -m http.server 5183" 2>/dev/null || true  
-	@pkill -f "vite.*--port 5183" 2>/dev/null || true
+	@pkill -f "npm.*preview.*4173" 2>/dev/null || true
 	@echo "✅ All servers stopped and ports cleaned up"
 
 clean: ## Clean build artifacts

--- a/backend/src/__tests__/unit/config.test.ts
+++ b/backend/src/__tests__/unit/config.test.ts
@@ -43,7 +43,7 @@ describe('config', () => {
 
     jest.isolateModules(() => {
       const { config } = require('../../config');
-      expect(config.port).toBe(3001);
+      expect(config.port).toBe(3010);
     });
   });
 });

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -47,7 +47,7 @@ function getConfig(): Config {
   const tempDir = process.env.TEMP_DIR || path.join(process.cwd(), 'data', 'temp');
 
   return {
-    port: parseIntOrDefault(process.env.PORT, 3001),
+    port: parseIntOrDefault(process.env.PORT, 3010),
     nodeEnv: process.env.NODE_ENV || 'development',
     logLevel: process.env.LOG_LEVEL || 'info',
     videosDir,

--- a/scripts/wait-for-it.sh
+++ b/scripts/wait-for-it.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Wait for a service to be available
+# Usage: ./scripts/wait-for-it.sh <url> [timeout]
+
+set -e
+
+URL="${1:-}"
+MAX_ATTEMPTS="${2:-30}"
+ATTEMPT=0
+
+if [ -z "$URL" ]; then
+    echo "Usage: $0 <url> [timeout]"
+    exit 1
+fi
+
+echo "⏳ Waiting for service at $URL..."
+
+while [ $ATTEMPT -lt $MAX_ATTEMPTS ]; do
+    if curl -sf "$URL" > /dev/null 2>&1; then
+        echo "✅ Service is responding at $URL"
+        exit 0
+    fi
+    ATTEMPT=$((ATTEMPT + 1))
+    echo "   Attempt $ATTEMPT/$MAX_ATTEMPTS..."
+    sleep 2
+done
+
+echo "❌ Service failed to respond at $URL after $MAX_ATTEMPTS attempts"
+exit 1


### PR DESCRIPTION
## Summary

The `make start` command does not reliably start the backend server due to missing error handling in the build process, no startup verification, and a port configuration mismatch between the Makefile (3010) and config defaults (3001).

## Root Cause

**5 Whys Analysis:**
1. Why does `make start` fail intermittently? → Build failures are not caught and the script continues
2. Why aren't build failures detected? → The Makefile uses `@` prefix with no error handling or `|| exit 1` fallback
3. Why does the backend start on wrong port sometimes? → Config default is 3001 but Makefile uses PORT=3010
4. Why doesn't the script verify backend is responding? → No health check waiting logic exists
5. Why do users see "Terminated" with no error message? → The make process terminates on first error without cleanup or clear messaging

## Changes

| File | Change |
|------|--------|
| `backend/src/config.ts` | Changed default port from 3001 to 3010 |
| `backend/src/__tests__/unit/config.test.ts` | Updated test to expect new default port 3010 |
| `Makefile` | Added error handling to build target with clear failure messages |
| `Makefile` | Improved start target with health checks and proper status reporting |
| `Makefile` | Updated stop target for new frontend port (4173) with vite preview |
| `scripts/wait-for-it.sh` | New health check script for service verification |

## Testing

- [x] Type check passes
- [x] Unit tests pass (210 passed, 5 skipped)
- [x] Frontend tests pass (143 passed)
- [x] Lint passes
- [x] Build completes successfully with new error handling
- [x] Health check script works for both success and failure cases

## Validation

```bash
# Run project's validation commands
make type-check && make test && make lint && make build
```

## Issue

Fixes #176

---

<details>
<summary>📋 Implementation Details</summary>

### Implementation followed artifact:

Investigation comment in issue #176

### Deviations from plan:

- Fixed failing test in `backend/src/__tests__/unit/config.test.ts` to expect new default port 3010
- All other changes implemented exactly as specified in the artifact

</details>

---

_Automated implementation from investigation artifact_