### PR TITLE
Fix: Network errors show as 500 instead of connection errors (#174)

### DIFF
--- a/frontend/src/__tests__/api.test.ts
+++ b/frontend/src/__tests__/api.test.ts
@@ -8,7 +8,8 @@ import {
   formatFileSize,
   formatDuration,
   checkBackendHealth,
-  ApiError 
+  ApiError,
+  ErrorStatus
 } from '../services/api';
 import { Video } from '../types';
 
@@ -80,6 +81,15 @@ describe('API Service', () => {
         expect((error as ApiError).status).toBe(0);
         expect((error as ApiError).message).toBe('Network connection failed');
       }
+    });
+
+    test('should have ErrorStatus constants', () => {
+      expect(ErrorStatus.NETWORK).toBe(0);
+      expect(ErrorStatus.BAD_REQUEST).toBe(400);
+      expect(ErrorStatus.UNAUTHORIZED).toBe(401);
+      expect(ErrorStatus.FORBIDDEN).toBe(403);
+      expect(ErrorStatus.NOT_FOUND).toBe(404);
+      expect(ErrorStatus.SERVER_ERROR).toBe(500);
     });
   });
 

--- a/frontend/src/__tests__/error.test.ts
+++ b/frontend/src/__tests__/error.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect } from 'vitest';
-import { getErrorMessage } from '../lib/error';
+import { getErrorMessage, isNetworkError, getUserFriendlyErrorMessage } from '../lib/error';
+import { ApiError } from '../services/api';
 
 describe('frontend error utilities', () => {
   describe('getErrorMessage', () => {
@@ -41,6 +42,53 @@ describe('frontend error utilities', () => {
       }
       const error = new CustomError('Custom message');
       expect(getErrorMessage(error)).toBe('Custom message');
+    });
+  });
+
+  describe('isNetworkError', () => {
+    test('should return true for ApiError with status 0', () => {
+      expect(isNetworkError(new ApiError('Failed', 0))).toBe(true);
+    });
+
+    test('should return false for ApiError with status 500', () => {
+      expect(isNetworkError(new ApiError('Failed', 500))).toBe(false);
+    });
+
+    test('should return true for Error with "Failed to fetch" message', () => {
+      expect(isNetworkError(new Error('Failed to fetch'))).toBe(true);
+    });
+
+    test('should return true for Error with case-insensitive network error messages', () => {
+      expect(isNetworkError(new Error('NetworkError: Failed to load'))).toBe(true);
+      expect(isNetworkError(new Error('net::ERR_INTERNET_DISCONNECTED'))).toBe(true);
+    });
+
+    test('should return false for non-network errors', () => {
+      expect(isNetworkError(new Error('Server error'))).toBe(false);
+      expect(isNetworkError('string error')).toBe(false);
+      expect(isNetworkError(null)).toBe(false);
+    });
+  });
+
+  describe('getUserFriendlyErrorMessage', () => {
+    test('should return "unavailable" message for network errors', () => {
+      const msg = getUserFriendlyErrorMessage(new ApiError('Failed', 0));
+      expect(msg).toContain('unavailable');
+    });
+
+    test('should return original message for server errors', () => {
+      const msg = getUserFriendlyErrorMessage(new ApiError('Server Error', 500));
+      expect(msg).toBe('Server Error');
+    });
+
+    test('should return friendly message for generic network errors', () => {
+      const msg = getUserFriendlyErrorMessage(new Error('Failed to fetch'));
+      expect(msg).toContain('Backend server unavailable');
+    });
+
+    test('should return original message for non-network errors', () => {
+      const msg = getUserFriendlyErrorMessage(new Error('Validation failed'));
+      expect(msg).toBe('Validation failed');
     });
   });
 });

--- a/frontend/src/components/DownloadQueue.tsx
+++ b/frontend/src/components/DownloadQueue.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { getErrorMessage } from '../lib/error';
+import { getUserFriendlyErrorMessage } from '../lib/error';
 import { Card, CardDescription, CardHeader, CardTitle } from './ui/card';
 import { Button } from './ui/button';
 import { Alert, AlertDescription } from './ui/alert';
@@ -151,7 +151,7 @@ export function DownloadQueue({ className = '' }: DownloadQueueProps) {
           <CardTitle>Download Queue</CardTitle>
           <Alert variant="destructive">
             <AlertDescription>
-              Failed to load download queue: {getErrorMessage(error)}
+              Failed to load download queue: {getUserFriendlyErrorMessage(error)}
             </AlertDescription>
           </Alert>
         </CardHeader>

--- a/frontend/src/components/VideoGrid/VideoGrid.tsx
+++ b/frontend/src/components/VideoGrid/VideoGrid.tsx
@@ -5,6 +5,7 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import { AlertCircle, RefreshCw } from 'lucide-react';
+import { getUserFriendlyErrorMessage } from '../../lib/error';
 
 export function VideoGrid({ 
   videos, 
@@ -42,7 +43,7 @@ export function VideoGrid({
           <Alert variant="destructive" className="max-w-md">
             <AlertCircle className="h-4 w-4" />
             <AlertDescription data-testid="error-message">
-              Error loading videos: {error}
+              Error loading videos: {getUserFriendlyErrorMessage(error)}
             </AlertDescription>
           </Alert>
           <Button 

--- a/frontend/src/components/YouTubeDownload.tsx
+++ b/frontend/src/components/YouTubeDownload.tsx
@@ -4,6 +4,7 @@ import { Button } from './ui/button';
 import { Alert, AlertDescription } from './ui/alert';
 import { useYouTubeDownload } from '../hooks/useYouTube';
 import { validateYouTubeUrl } from '../services/youtube';
+import { getUserFriendlyErrorMessage } from '../lib/error';
 
 interface YouTubeDownloadProps {
   className?: string;
@@ -90,9 +91,7 @@ export function YouTubeDownload({ className = '' }: YouTubeDownloadProps) {
           {downloadMutation.isError && (
             <Alert variant="destructive" data-testid="download-error">
               <AlertDescription>
-                {downloadMutation.error instanceof Error 
-                  ? downloadMutation.error.message 
-                  : 'Failed to start download. Please check the URL and try again.'}
+                {getUserFriendlyErrorMessage(downloadMutation.error)}
               </AlertDescription>
             </Alert>
           )}

--- a/frontend/src/lib/error.ts
+++ b/frontend/src/lib/error.ts
@@ -1,4 +1,26 @@
 // New file - utility for error message extraction
+import { ApiError } from '../services/api';
+
 export function getErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+export function isNetworkError(error: unknown): boolean {
+  if (error instanceof ApiError) {
+    return error.status === 0;
+  }
+  if (error instanceof Error) {
+    const message = error.message.toLowerCase();
+    return message.includes('failed to fetch') ||
+           message.includes('networkerror') ||
+           message.includes('net::err');
+  }
+  return false;
+}
+
+export function getUserFriendlyErrorMessage(error: unknown): string {
+  if (isNetworkError(error)) {
+    return 'Backend server unavailable. Please check your connection and try again.';
+  }
+  return getErrorMessage(error);
 }

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -9,7 +9,7 @@ export const API_BASE_URL = (configuredApiBaseUrl || '/api').replace(/\/$/, '');
 /**
  * Custom error class for API errors
  */
-class ApiError extends Error {
+export class ApiError extends Error {
   constructor(
     message: string,
     public status: number = 500,
@@ -19,6 +19,15 @@ class ApiError extends Error {
     this.name = 'ApiError';
   }
 }
+
+export const ErrorStatus = {
+  NETWORK: 0,
+  BAD_REQUEST: 400,
+  UNAUTHORIZED: 401,
+  FORBIDDEN: 403,
+  NOT_FOUND: 404,
+  SERVER_ERROR: 500,
+} as const;
 
 /**
  * Generic fetch wrapper with error handling
@@ -140,9 +149,6 @@ export function formatDuration(seconds?: number): string {
 
   return `${minutes}:${remainingSeconds.toString().padStart(2, '0')}`;
 }
-
-// Export the ApiError for use in components
-export { ApiError };
 
 /**
  * Backend health status response


### PR DESCRIPTION
## Summary

When the backend server is unavailable, API calls from the frontend display misleading 500 Internal Server Error messages instead of clear "Backend unavailable" or "Connection failed" messages. Users cannot distinguish between actual server errors (HTTP 500) and network/connection failures (status 0).

## Root Cause

The issue has two contributing factors:
1. **UI components don't check error status** - Components only display `error.message` without checking `error.status` to differentiate network vs server errors
2. **No centralized error categorization** - There's no utility function to determine if an error is a network error (status=0) vs a server error (status=500)

The code correctly sets `status=0` for network errors in api.ts, but this information was never used by UI components to display appropriate messages.

## Changes

| File | Change |
|------|--------|
| `frontend/src/lib/error.ts` | Added isNetworkError() and getUserFriendlyErrorMessage() utilities |
| `frontend/src/services/api.ts` | Exported ApiError class and added ErrorStatus constants |
| `frontend/src/components/VideoGrid/VideoGrid.tsx` | Updated error display to use getUserFriendlyErrorMessage() |
| `frontend/src/components/YouTubeDownload.tsx` | Updated error display to use getUserFriendlyErrorMessage() |
| `frontend/src/components/DownloadQueue.tsx` | Updated error display to use getUserFriendlyErrorMessage() |
| `frontend/src/__tests__/error.test.ts` | Added comprehensive tests for new error utilities |
| `frontend/src/__tests__/api.test.ts` | Added test for ErrorStatus constants |

## Testing

- [x] Type check passes
- [x] Unit tests pass (162 tests)
- [x] Lint passes
- [x] Build validation passes

## Validation

```bash
cd frontend && npm run type-check && npm test -- --run && npm run lint
```

## Issue

Fixes #174

---

<details>
<summary>📋 Implementation Details</summary>

### Implementation followed artifact:

Investigation comment on issue #174

### Deviations from plan:

None - all steps from the artifact were executed exactly as specified.

</details>

---

_Automated implementation from investigation artifact_