### PR TITLE
Fix: Thumbnail directory mismatch causing missing video thumbnails (#181)

### DIFF
--- a/backend/src/__tests__/unit/services/videoService.test.ts
+++ b/backend/src/__tests__/unit/services/videoService.test.ts
@@ -29,9 +29,10 @@ const mockFs = fs as jest.Mocked<typeof fs>;
 describe('VideoService', () => {
   let videoService: VideoService;
   const testVideosDir = '/test/videos';
+  const testThumbnailsDir = '/test/thumbnails';
 
   beforeEach(() => {
-    videoService = new VideoService(testVideosDir);
+    videoService = new VideoService(testVideosDir, testThumbnailsDir);
     jest.clearAllMocks();
   });
 
@@ -393,7 +394,8 @@ describe('VideoService', () => {
 
     it('should use default path when VIDEOS_DIR is not set', () => {
       const service = new VideoService(
-        process.env.VIDEOS_DIR || path.join(process.cwd(), 'data', 'videos')
+        process.env.VIDEOS_DIR || path.join(process.cwd(), 'data', 'videos'),
+        '/test/thumbnails'
       );
       const filePath = service.getVideoFilePath('test.mp4');
       expect(filePath).toBe(path.join('/mock/cwd', 'data', 'videos', 'test.mp4'));
@@ -402,7 +404,8 @@ describe('VideoService', () => {
     it('should use environment variable override when VIDEOS_DIR is set', () => {
       process.env.VIDEOS_DIR = '/custom/videos';
       const service = new VideoService(
-        process.env.VIDEOS_DIR || path.join(process.cwd(), 'data', 'videos')
+        process.env.VIDEOS_DIR || path.join(process.cwd(), 'data', 'videos'),
+        '/test/thumbnails'
       );
       const filePath = service.getVideoFilePath('test.mp4');
       expect(filePath).toBe(path.join('/custom/videos', 'test.mp4'));
@@ -410,7 +413,8 @@ describe('VideoService', () => {
 
     it('should produce absolute paths', () => {
       const service = new VideoService(
-        process.env.VIDEOS_DIR || path.join(process.cwd(), 'data', 'videos')
+        process.env.VIDEOS_DIR || path.join(process.cwd(), 'data', 'videos'),
+        '/test/thumbnails'
       );
       const filePath = service.getVideoFilePath('test.mp4');
       expect(path.isAbsolute(filePath)).toBe(true);
@@ -419,7 +423,8 @@ describe('VideoService', () => {
     it('should not contain dangerous path traversals in default path', () => {
       delete process.env.VIDEOS_DIR;
       const service = new VideoService(
-        process.env.VIDEOS_DIR || path.join(process.cwd(), 'data', 'videos')
+        process.env.VIDEOS_DIR || path.join(process.cwd(), 'data', 'videos'),
+        '/test/thumbnails'
       );
       const filePath = service.getVideoFilePath('test.mp4');
       expect(filePath).not.toContain('../');
@@ -427,10 +432,56 @@ describe('VideoService', () => {
 
     it('should handle absolute custom path from environment variable', () => {
       process.env.VIDEOS_DIR = '/absolute/custom/path';
-      const service = new VideoService(process.env.VIDEOS_DIR);
+      const service = new VideoService(process.env.VIDEOS_DIR, '/test/thumbnails');
       const filePath = service.getVideoFilePath('video.mp4');
       expect(filePath).toBe('/absolute/custom/path/video.mp4');
       expect(path.isAbsolute(filePath)).toBe(true);
+    });
+  });
+
+  describe('findThumbnail (thumbnails directory fallback)', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should find thumbnail in thumbnails directory when not in video directory', async () => {
+      const serviceWithThumbnails = new VideoService('/test/videos', '/test/thumbnails');
+      
+      mockFs.access
+        .mockRejectedValueOnce(new Error('ENOENT')) // video dir search fails
+        .mockRejectedValueOnce(new Error('ENOENT')) // video dir .jpeg fails
+        .mockRejectedValueOnce(new Error('ENOENT')) // video dir .png fails  
+        .mockRejectedValueOnce(new Error('ENOENT')) // video dir .webp fails
+        .mockRejectedValueOnce(new Error('ENOENT')) // thumbnails dir .jpg fails
+        .mockResolvedValueOnce(undefined); // thumbnails dir .jpeg succeeds
+
+      const result = await (serviceWithThumbnails as any).findThumbnail('/test/videos/video.mp4');
+
+      expect(result).toBe('video.jpeg');
+      expect(mockFs.access).toHaveBeenCalledWith('/test/thumbnails/video.jpeg');
+    });
+
+    it('should prefer thumbnail in video directory over thumbnails directory', async () => {
+      const serviceWithThumbnails = new VideoService('/test/videos', '/test/thumbnails');
+      
+      mockFs.access.mockResolvedValue(undefined);
+
+      const result = await (serviceWithThumbnails as any).findThumbnail('/test/videos/video.mp4');
+
+      expect(result).toBe('video.jpg');
+      expect(mockFs.access).toHaveBeenCalledWith('/test/videos/video.jpg');
+      expect(mockFs.access).toHaveBeenCalledTimes(1);
+    });
+
+    it('should return null when thumbnail not in either directory', async () => {
+      const serviceWithThumbnails = new VideoService('/test/videos', '/test/thumbnails');
+      
+      mockFs.access.mockRejectedValue(new Error('ENOENT'));
+      mockFs.readdir.mockResolvedValue(['other.jpg'] as any);
+
+      const result = await (serviceWithThumbnails as any).findThumbnail('/test/videos/video.mp4');
+
+      expect(result).toBeNull();
     });
   });
 });

--- a/backend/src/routes/api.ts
+++ b/backend/src/routes/api.ts
@@ -13,7 +13,7 @@ const router = Router();
 // Initialize video service (in production this would come from DI container)
 const videosDirectory = config.videosDir;
 const tempDirectory = config.tempDir;
-const videoService = new VideoService(videosDirectory);
+const videoService = new VideoService(videosDirectory, config.thumbnailsDir);
 const MAX_THUMBNAIL_SIZE = config.thumbnailMaxSize;
 const THUMBNAIL_CACHE_DURATION = config.thumbnailCacheDuration;
 

--- a/backend/src/routes/health/probes.ts
+++ b/backend/src/routes/health/probes.ts
@@ -107,7 +107,7 @@ export async function getVideoServiceHealth(): Promise<VideoServiceHealth> {
 
   try {
     const { VideoService } = await import('../../services/videoService');
-    const videoService = new VideoService(getVideosDirectory());
+    const videoService = new VideoService(getVideosDirectory(), config.thumbnailsDir);
     const result = await videoService.scanVideoDirectory();
 
     health.lastScan = new Date().toISOString();

--- a/backend/src/services/videoService.ts
+++ b/backend/src/services/videoService.ts
@@ -17,12 +17,14 @@ import {
  */
 export class VideoService {
   private readonly videosDirectory: string;
+  private readonly thumbnailsDirectory: string;
   private thumbnailCache: Map<string, { files: string[]; timestamp: number }> = new Map();
   private readonly CACHE_TTL = 5 * 60 * 1000;
   private readonly THUMBNAIL_EXTENSIONS = ['.jpg', '.jpeg', '.png', '.webp'];
 
-  constructor(videosDirectory: string) {
+  constructor(videosDirectory: string, thumbnailsDirectory: string) {
     this.videosDirectory = videosDirectory;
+    this.thumbnailsDirectory = thumbnailsDirectory;
   }
 
   /**
@@ -198,8 +200,17 @@ export class VideoService {
     const videoDir = path.dirname(videoPath);
     const baseName = path.basename(videoPath, path.extname(videoPath));
     
+    const thumbnail = await this.findThumbnailInDirectory(videoDir, baseName);
+    if (thumbnail) {
+      return thumbnail;
+    }
+
+    return this.findThumbnailInDirectory(this.thumbnailsDirectory, baseName);
+  }
+
+  private async findThumbnailInDirectory(directory: string, baseName: string): Promise<string | null> {
     for (const ext of this.THUMBNAIL_EXTENSIONS) {
-      const exactThumbPath = path.join(videoDir, baseName + ext);
+      const exactThumbPath = path.join(directory, baseName + ext);
       try {
         await fs.access(exactThumbPath);
         return baseName + ext;
@@ -209,7 +220,7 @@ export class VideoService {
     }
 
     try {
-      const files = await fs.readdir(videoDir);
+      const files = await fs.readdir(directory);
       const lowerBaseName = baseName.toLowerCase();
 
       for (const ext of this.THUMBNAIL_EXTENSIONS) {
@@ -306,5 +317,6 @@ export class VideoService {
  * Uses environment variable or default path
  */
 export const videoService = new VideoService(
-  config.videosDir
+  config.videosDir,
+  config.thumbnailsDir
 );


### PR DESCRIPTION
## Summary

Thumbnails are generated by ThumbnailService in `data/temp/thumbnails/` directory but VideoService.findThumbnail() only searches in the video's parent directory, causing all video metadata to have `thumbnail: null` and no thumbnails displayed in UI.

## Root Cause

Directory mismatch between thumbnail generation and thumbnail search:
- **Generated**: `data/temp/thumbnails/video.jpg` (by ThumbnailService)  
- **Searched**: `data/videos/video.jpg` (by VideoService.findThumbnail())
- **Result**: All videos have `thumbnail: null`, frontend displays no images

## Changes

| File | Change |
|------|--------|
| `backend/src/services/videoService.ts` | Added thumbnailsDirectory parameter, updated findThumbnail() with fallback |
| `backend/src/routes/api.ts` | Updated VideoService instantiation with thumbnailsDir |
| `backend/src/routes/health/probes.ts` | Updated VideoService instantiation with thumbnailsDir |
| `backend/src/__tests__/unit/services/videoService.test.ts` | Added comprehensive tests for thumbnail directory fallback |

## Testing

- [x] Type check passes
- [x] Unit tests pass (36/36 VideoService tests)
- [x] All tests pass (375 total: 213 backend + 162 frontend)
- [x] Lint passes
- [x] Build validation passes

## Validation

```bash
# Run project's validation commands
cd backend && npm run type-check && npm test -- --testPathPattern="videoService" && npm run lint
```

## Issue

Fixes #181

---

<details>
<summary>📋 Implementation Details</summary>

### Implementation followed artifact:

Investigation comment from issue #181 (github-actions)

### Deviations from plan:

None - implementation followed the artifact exactly as specified.

</details>

---

_Automated implementation from investigation artifact_