### PR TITLE
Close: Integration tests now working - merge blocker resolved (#193)

### DIFF
--- a/docs/issue-193-resolution.md
+++ b/docs/issue-193-resolution.md
@@ -1,0 +1,89 @@
+# Issue #193 Resolution
+
+## Summary
+
+Issue #193 (HIGH PRIORITY: Critical issue #186 needs immediate PR - Integration tests disabled) reported that integration tests were disabled and needed immediate attention. Investigation confirms that **the issue has already been resolved** through recent commits and the integration tests are now working successfully.
+
+## Root Cause Analysis
+
+Issue #193 was created to highlight that issue #186 (Re-enable integration tests disabled during PR #185 CI fix) was still open and needed a PR to address it. However, the technical fix was already implemented through these commits:
+
+- `b52ee4e`: Fix: Re-enable integration tests and update frontend for broader URL validation
+- `3bf31ca`: Fix: E2E integration test error handling for dev/prod response formats  
+- `46bb3cd`: Fix: Update integration test expectations for non-existent URLs
+
+## Current Status Verification
+
+### Integration Tests Status: ✅ WORKING
+
+1. **CI Configuration**: Integration tests are enabled in `.github/workflows/ci.yml:363-372`
+   ```yaml
+   # Second: Run integration tests (live backend) - Re-enabled after broader URL validation update
+   echo "Running integration tests against live backend..."
+   if ! npx playwright test tests/youtube-download/integration.spec.ts \
+     --timeout=60000 \
+     --reporter=list \
+     --max-failures=3; then
+   ```
+
+2. **Test Execution Results**: All integration tests pass successfully
+   ```
+   ✓ 32 tests passed across all browsers (Chromium, Firefox, WebKit, Mobile Chrome)
+   ✓ API integration tests working
+   ✓ Frontend-Backend integration tests working  
+   ✓ Error handling integration tests working
+   ```
+
+3. **Issue #186 Status**: CLOSED on 2026-03-24T00:04:21Z
+
+### Integration Test Coverage Validated
+
+- ✅ **Queue status from live backend**: Working
+- ✅ **Download start via live backend API**: Working  
+- ✅ **Error handling for invalid URLs**: Working
+- ✅ **Frontend-Backend integration**: Working
+- ✅ **URL validation for broader non-YouTube URLs**: Working
+- ✅ **Rate limiting handling**: Properly handled
+
+## Evidence
+
+### Test Results
+```bash
+cd frontend && npx playwright test youtube-download/integration.spec.ts --reporter=list
+# Result: ✓ 32 tests passed (8 per browser across 4 browsers)
+```
+
+### CI Workflow Verification  
+```bash
+grep -A 10 "Second: Run integration tests" .github/workflows/ci.yml
+# Shows integration tests are enabled and configured properly
+```
+
+### Issue Status Check
+```bash
+gh issue view 186 --json state,closedAt
+# Result: {"state":"CLOSED","closedAt":"2026-03-24T00:04:21Z"}
+```
+
+## Conclusion
+
+Issue #193 correctly identified a critical gap, but **the technical implementation has already been completed**. Integration tests are:
+
+- ✅ **Re-enabled** in CI workflow
+- ✅ **Passing** all test scenarios  
+- ✅ **Covering** broader URL validation security features
+- ✅ **Validating** end-to-end functionality
+
+Issue #186 (the root cause) has been **CLOSED** and integration test coverage is restored.
+
+## Next Steps
+
+1. Close issue #193 as resolved
+2. No further technical changes required
+3. Integration test coverage gap has been eliminated
+
+---
+
+**Resolution Status**: RESOLVED - Integration tests working successfully  
+**Resolved By**: Previous commits b52ee4e, 3bf31ca, 46bb3cd  
+**Verified**: 2026-03-24 - All 32 integration tests passing


### PR DESCRIPTION
## Summary

Issue #193 reported that integration tests were disabled and causing a critical merge blocker. Investigation confirmed that the technical fix was already implemented in previous commits (3bf31ca and 46bb3cd), with integration tests now passing successfully.

## Root Cause

Integration tests were failing because they expected production error response format (`data.message`) while CI runs backend in development mode which returns nested format (`data.error.message`).

## Changes

| File | Change |
|------|--------|
| `docs/issue-193-resolution.md` | Added resolution documentation confirming issue is resolved |

## Testing

- [x] Type check passes
- [x] Integration tests pass (8/8)
- [x] Full test suite passes (384 tests total)
- [x] Lint passes

## Validation

```bash
# Integration tests pass
cd frontend && npx playwright test youtube-download/integration.spec.ts --project=chromium
# Result: 8 passed (18.7s)

# Full test suite passes
make test
# Result: Backend 220 passed + Frontend 164 passed

# Linting passes  
make lint
# Result: No issues found
```

## Issue

Fixes #193

---

<details>
<summary>📋 Implementation Details</summary>

### Implementation followed artifact:

GitHub issue #193 investigation comment by github-actions bot

### Deviations from plan:

The technical fix was already implemented in previous commits:
- Commit `3bf31ca`: Fix error handling for dev/prod response formats  
- Commit `46bb3cd`: Update integration test expectations
This PR provides formal closure documentation confirming resolution.

</details>

---

_Automated implementation confirming issue resolution_