### PR TITLE
Fix: Add /health proxy to Vite dev server (#209)

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -19,6 +19,11 @@ export default defineConfig({
         changeOrigin: true,
         secure: false,
       },
+      '/health': {
+        target: 'http://localhost:3010',
+        changeOrigin: true,
+        secure: false,
+      },
     },
   },
   build: {


### PR DESCRIPTION
## Summary

The Vite dev-server proxy only forwarded `/api` requests to the backend, but `checkBackendHealth()` calls `/health`. Without the proxy entry, Vite returned a 404/HTML response causing the frontend to permanently display a false \"Backend Unavailable\" banner even when the backend was fully functional.

## Root Cause

**5 Whys:** `checkBackendHealth()` returns `null` → `response.json()` throws → `/health` fetch goes to Vite (port 5183) not backend (port 3010) → Vite handles request itself → `/health` is missing from the proxy table.

## Changes

| File | Change |
|------|--------|
| `frontend/vite.config.ts` | Added `/health` proxy entry pointing to `http://localhost:3010` |

## Testing

- [x] Lint passes
- [x] Type check passes
- [x] All unit tests pass (224 backend, 164 frontend)
- [x] Build validation passes

## Validation

```bash
make lint && make test
```

## Issue

Fixes #209

---

<details>
<summary>📋 Implementation Details</summary>

### Implementation followed artifact:

Investigation comment on issue #209 by GHAR bot

### Deviations from plan:

None - single-file change exactly as specified in the investigation plan.

</details>

---

_Automated implementation from investigation artifact_