### PR TITLE
Fix: parse stdout JSON in YouTubeMetadataExtractor (#207)

### DIFF
--- a/backend/src/__tests__/unit/services/youTubeMetadataExtractor.test.ts
+++ b/backend/src/__tests__/unit/services/youTubeMetadataExtractor.test.ts
@@ -6,7 +6,7 @@ jest.mock('youtube-dl-exec', () => ({
   exec: (...args: any[]) => mockExec(...args)
 }));
 
-// Mock validation utility
+// Mock validation utility - pass through parsed data
 jest.mock('../../../utils/validation', () => ({
   validateYtDlpResponse: jest.fn((data) => data)
 }));
@@ -29,7 +29,14 @@ describe('YouTubeMetadataExtractor', () => {
         uploader: 'Test Channel'
       };
 
-      const mockSubprocess = Promise.resolve(mockMetadata);
+      // youtube-dl-exec.exec() returns process result object with stdout containing JSON
+      const mockProcessResult = {
+        stdout: JSON.stringify(mockMetadata),
+        stderr: '',
+        pid: 12345
+      };
+
+      const mockSubprocess = Promise.resolve(mockProcessResult);
       (mockSubprocess as any).stderr = { on: jest.fn() };
       mockExec.mockReturnValue(mockSubprocess);
 
@@ -57,7 +64,14 @@ describe('YouTubeMetadataExtractor', () => {
         title: 'Test Video'
       };
 
-      const mockSubprocess = Promise.resolve(mockMetadata);
+      // youtube-dl-exec.exec() returns process result object with stdout containing JSON
+      const mockProcessResult = {
+        stdout: JSON.stringify(mockMetadata),
+        stderr: '',
+        pid: 12345
+      };
+
+      const mockSubprocess = Promise.resolve(mockProcessResult);
       (mockSubprocess as any).stderr = { on: jest.fn() };
       mockExec.mockReturnValue(mockSubprocess);
 
@@ -85,7 +99,14 @@ describe('YouTubeMetadataExtractor', () => {
         channel: 'Test Channel'
       };
 
-      const mockSubprocess = Promise.resolve(mockMetadata);
+      // youtube-dl-exec.exec() returns process result object with stdout containing JSON
+      const mockProcessResult = {
+        stdout: JSON.stringify(mockMetadata),
+        stderr: '',
+        pid: 12345
+      };
+
+      const mockSubprocess = Promise.resolve(mockProcessResult);
       (mockSubprocess as any).stderr = { on: jest.fn() };
       mockExec.mockReturnValue(mockSubprocess);
 

--- a/backend/src/services/youTubeMetadataExtractor.ts
+++ b/backend/src/services/youTubeMetadataExtractor.ts
@@ -24,7 +24,8 @@ export class YouTubeMetadataExtractor {
         stderrOutput += data.toString();
       });
 
-      const rawMetadata = await subprocess;
+      const processResult = await subprocess;
+      const rawMetadata = JSON.parse(processResult.stdout);
       const metadata = validateYtDlpResponse(rawMetadata);
 
       const result: YouTubeMetadata = {


### PR DESCRIPTION
## Summary

`YouTubeMetadataExtractor.extract()` was passing the raw ChildProcess/execa result object from `youtubedl.exec()` directly to `validateYtDlpResponse()` without parsing `result.stdout` as JSON. This caused all YouTube-specific fields (id, title, etc.) to be `undefined`, triggering fallbacks that generated random UUIDs and 'Unknown Title' for every download.

## Root Cause

`youtubedl.exec()` resolves to a process result object `{stdout: string, stderr: string, pid: number}`, not a parsed metadata object. The JSON metadata is in `stdout` and must be parsed before validation. Because `YtDlpResponseSchema` has all fields as `.optional()`, Zod's `safeParse` succeeded on the process-result object but silently returned all YouTube fields as `undefined`.

## Changes

| File | Change |
|------|--------|
| `backend/src/services/youTubeMetadataExtractor.ts` | Added `JSON.parse(processResult.stdout)` before `validateYtDlpResponse()` call |
| `backend/src/__tests__/unit/services/youTubeMetadataExtractor.test.ts` | Updated all test mocks to return process result objects `{stdout: JSON.stringify(metadata), ...}` reflecting real library behavior |

## Testing

- [x] Type check passes (`npm run type-check`)
- [x] All 225 backend unit/integration tests pass
- [x] All 164 frontend tests pass
- [x] Lint passes

## Validation

```bash
cd backend && npm run test -- --testPathPattern="youTubeMetadataExtractor"
cd backend && npm run lint
cd backend && npm run type-check
```

## Issue

Fixes #207

---

<details>
<summary>📋 Implementation Details</summary>

### Implementation followed artifact:

Investigation comment on issue #207 (posted by github-actions/GHAR)

### Deviations from plan:

None — changes exactly as specified in the investigation plan.

</details>

---

_Automated implementation from investigation artifact_