### PR TITLE
Chore: Record RCA and CI verification for issue #215 in task ledger

### DIFF
--- a/dev/state/task-ledger.json
+++ b/dev/state/task-ledger.json
@@ -99,5 +99,30 @@
       "Commit and push pending CI verification"
     ],
     "last_verified": "2026-03-25T07:20:00Z"
+  },
+  "ISSUE_215_ROOT_CAUSE_ANALYSIS": {
+    "status": "done",
+    "evidence": [
+      "gh issue view 215 -> DEBT: Add empty stdout guard in YouTubeMetadataExtractor before JSON.parse",
+      "5xWhy analysis:",
+      "  Why1: JSON.parse('') throws SyntaxError with non-descriptive message when yt-dlp returns empty stdout",
+      "  Why2: yt-dlp may exit cleanly (no error) in edge cases (network issues, binary misbehavior) producing only stderr",
+      "  Why3: Catch block wrapped error as AppError but with raw SyntaxError message, masking root cause in prod logs",
+      "  Why4: Original code assumed yt-dlp always produces JSON on stdout on clean exit — edge cases not modelled",
+      "  Why5: No unit test covered empty-stdout scenario; only happy path and subprocess rejection were tested",
+      "Root cause: Missing precondition guard on processResult.stdout before JSON.parse, and no test for empty-stdout edge case"
+    ],
+    "last_verified": "2026-03-25T10:15:00Z"
+  },
+  "ISSUE_215_FIX_VERIFY_PR_216": {
+    "status": "done",
+    "evidence": [
+      "gh pr view 216 -> mergeStateStatus: CLEAN, mergeable: MERGEABLE",
+      "gh run view 23535669196 -> conclusion: success (all 6 CI jobs passed)",
+      "PR #216 adds: if (!processResult.stdout?.trim()) throw new AppError('yt-dlp returned empty stdout — no JSON metadata received', 500)",
+      "PR #216 adds unit test: 'should throw descriptive error when yt-dlp returns empty stdout'",
+      "CI jobs passed: Level 1 Static Analysis, Level 2 Build, Level 3 Unit Tests, Level 4 E2E Tests, Level 5 Integration, CI Pipeline Complete"
+    ],
+    "last_verified": "2026-03-25T10:15:00Z"
   }
 }


### PR DESCRIPTION
## Problem
The task ledger (`dev/state/task-ledger.json`) was missing entries documenting the root cause analysis for issue #215 (empty stdout SyntaxError in `YouTubeMetadataExtractor`) and the CI-verified evidence for PR #216 that fixed it.

## Solution
Added two new entries to the task ledger capturing the full audit trail — the 5xWhy RCA chain and the CI/PR evidence — so future agents and reviewers have complete context.

## Changes
- Added `ISSUE_215_ROOT_CAUSE_ANALYSIS` entry with 5xWhy reasoning chain
- Added `ISSUE_215_FIX_VERIFY_PR_216` entry with CI job pass evidence and PR merge state

## Testing
All 389 tests (225 backend + 164 frontend) passed during pre-commit hooks. Lint, type-check, and build validations passed during pre-push hooks.

## Example Output
```json
"ISSUE_215_ROOT_CAUSE_ANALYSIS": {
  "status": "done",
  "evidence": [
    "Why1: JSON.parse('') throws SyntaxError when yt-dlp returns empty stdout",
    ...
  ]
}
```

## Notes
No functional code changed — this is purely a task ledger bookkeeping update for audit trail completeness.