### PR TITLE
Fix: Strip internal filesystem paths from API responses (#221)

### DIFF
--- a/backend/src/__tests__/integration/routes/api.test.ts
+++ b/backend/src/__tests__/integration/routes/api.test.ts
@@ -76,6 +76,24 @@ describe('API Routes', () => {
   });
 
   describe('GET /api/videos', () => {
+    it('should return stream URLs instead of absolute paths in video list', async () => {
+      mockFsPromises.readdir.mockResolvedValue(['test-video.mp4'] as any);
+      mockFsPromises.stat.mockResolvedValue({
+        size: 1000000,
+        isFile: () => true,
+        isDirectory: () => false,
+        mtime: new Date('2026-03-01')
+      } as any);
+
+      const response = await request(app)
+        .get('/api/videos')
+        .expect(200);
+
+      expect(response.body.status).toBe('success');
+      expect(response.body.data.videos).toHaveLength(1);
+      expect(response.body.data.videos[0].file.path).toBe('/api/stream/test-video.mp4');
+    });
+
     it('should return list of videos', async () => {
       const response = await request(app)
         .get('/api/videos')

--- a/backend/src/__tests__/integration/routes/youtube.test.ts
+++ b/backend/src/__tests__/integration/routes/youtube.test.ts
@@ -114,6 +114,55 @@ describe('YouTube Routes', () => {
       expect(response.body.data.lastUpdated).toBe('2026-03-02T20:00:00.000Z');
     });
 
+    it('should NOT expose videoPath or thumbnailPath in queue response', async () => {
+      const mockQueueStatus = {
+        totalItems: 1,
+        processing: 0,
+        completed: 1,
+        failed: 0,
+        pending: 0,
+        cancelled: 0,
+        items: [{
+          id: 'queue-123',
+          request: {
+            url: 'https://www.youtube.com/watch?v=test123',
+            requestedAt: new Date('2026-03-02T20:00:00Z'),
+            requestId: 'req-123'
+          },
+          status: 'completed' as const,
+          progress: 100,
+          currentStep: 'Completed',
+          result: {
+            id: 'download-123',
+            status: 'success' as const,
+            videoPath: '/tmp/test.mp4',       // should NOT appear in response
+            thumbnailPath: '/tmp/thumb.jpg',  // should NOT appear in response
+            metadata: { id: 'test123', title: 'Video Title' },
+            startedAt: new Date('2026-03-02T20:01:00Z'),
+            completedAt: new Date('2026-03-02T20:02:00Z')
+          },
+          queuedAt: new Date('2026-03-02T20:00:00Z'),
+          startedAt: new Date('2026-03-02T20:01:00Z'),
+          completedAt: new Date('2026-03-02T20:02:00Z')
+        }],
+        lastUpdated: new Date('2026-03-02T20:03:00Z')
+      };
+
+      mockDownloadQueueService.getQueueStatus.mockReturnValue(mockQueueStatus);
+
+      const response = await request(app)
+        .get('/api/youtube/queue')
+        .expect(200);
+
+      expect(response.body.status).toBe('success');
+      const item = response.body.data.items[0];
+      expect(item.result).toBeDefined();
+      expect(item.result.videoPath).toBeUndefined();
+      expect(item.result.thumbnailPath).toBeUndefined();
+      expect(item.result.id).toBe('download-123');
+      expect(item.result.status).toBe('success');
+    });
+
     it('should transform queue items with top-level url and title fields', async () => {
       const mockQueueStatus = {
         totalItems: 1,

--- a/backend/src/routes/api.ts
+++ b/backend/src/routes/api.ts
@@ -26,9 +26,20 @@ router.get('/videos', catchAsync(async (_req: Request, res: Response) => {
   
   const result = await videoService.scanVideoDirectory();
   
+  const transformedResult = {
+    ...result,
+    videos: result.videos.map(video => ({
+      ...video,
+      file: {
+        ...video.file,
+        path: `/api/stream/${encodeURIComponent(video.file.name)}`
+      }
+    }))
+  };
+  
   res.json({
     status: 'success',
-    data: result
+    data: transformedResult
   });
 }));
 
@@ -47,9 +58,17 @@ router.get('/videos/:id', catchAsync(async (req: Request, res: Response) => {
     throw new AppError(`Video with id '${id}' not found`, 404);
   }
   
+  const transformedVideo = {
+    ...video,
+    file: {
+      ...video.file,
+      path: `/api/stream/${encodeURIComponent(video.file.name)}`
+    }
+  };
+  
   res.json({
     status: 'success',
-    data: video
+    data: transformedVideo
   });
 }));
 

--- a/backend/src/routes/youtube.ts
+++ b/backend/src/routes/youtube.ts
@@ -3,7 +3,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { logger } from '../utils/logger';
 import { catchAsync, AppError } from '../middleware/errorHandler';
 import { downloadQueueService, youTubeDownloadService } from '../services/index';
-import { DownloadRequest, QueueItem } from '../types/youtube';
+import { DownloadRequest } from '../types/youtube';
 import { createRateLimiter, rateLimitMiddleware } from '../middleware/rateLimiter';
 import { config } from '../config';
 
@@ -70,14 +70,25 @@ router.get('/queue', catchAsync(async (_req: Request, res: Response) => {
   
   const queueStatus = downloadQueueService.getQueueStatus();
 
-  const transformedItems = queueStatus.items.map(item => ({
-    ...item,
-    url: item.request.url,
-    title: item.request.title || item.result?.metadata?.title || item.request.url,
-    queuedAt: item.queuedAt instanceof Date ? item.queuedAt.toISOString() : item.queuedAt,
-    startedAt: item.startedAt instanceof Date ? item.startedAt.toISOString() : item.startedAt,
-    completedAt: item.completedAt instanceof Date ? item.completedAt.toISOString() : item.completedAt
-  }));
+  const transformedItems = queueStatus.items.map(item => {
+    const { result, ...rest } = item;
+    return {
+      ...rest,
+      url: item.request.url,
+      title: item.request.title || item.result?.metadata?.title || item.request.url,
+      queuedAt: item.queuedAt instanceof Date ? item.queuedAt.toISOString() : item.queuedAt,
+      startedAt: item.startedAt instanceof Date ? item.startedAt.toISOString() : item.startedAt,
+      completedAt: item.completedAt instanceof Date ? item.completedAt.toISOString() : item.completedAt,
+      result: result ? {
+        id: result.id,
+        status: result.status,
+        metadata: result.metadata,
+        error: result.error,
+        completedAt: result.completedAt instanceof Date ? result.completedAt.toISOString() : result.completedAt,
+        startedAt: result.startedAt instanceof Date ? result.startedAt.toISOString() : result.startedAt
+      } : undefined
+    };
+  });
 
   const transformedStatus = {
     ...queueStatus,
@@ -111,8 +122,21 @@ router.get('/download/:id/status', catchAsync(async (req: Request, res: Response
     throw new AppError(`Download with ID '${id}' not found`, 404);
   }
   
-  const responseData: QueueItem & { diagnostics?: any } = { ...queueItem };
-  
+  const { result, ...restItem } = queueItem;
+
+  const responseData: typeof restItem & { diagnostics?: any; result?: any } = { ...restItem };
+
+  if (result) {
+    responseData.result = {
+      id: result.id,
+      status: result.status,
+      metadata: result.metadata,
+      error: result.error,
+      completedAt: result.completedAt instanceof Date ? result.completedAt.toISOString() : result.completedAt,
+      startedAt: result.startedAt instanceof Date ? result.startedAt.toISOString() : result.startedAt
+    };
+  }
+
   // Add diagnostic context for failed downloads
   if (queueItem.status === 'failed' && queueItem.error) {
     responseData.diagnostics = {

--- a/backend/src/types/video.ts
+++ b/backend/src/types/video.ts
@@ -2,7 +2,10 @@
  * Video file system data structure
  */
 export interface VideoFile {
-  /** Full file system path to the video */
+  /**
+   * Internal: Full file system path to the video
+   * NOT exposed via API - use streamUrl for public access
+   */
   path: string;
   /** Filename with extension */
   name: string;

--- a/backend/src/types/youtube.ts
+++ b/backend/src/types/youtube.ts
@@ -50,9 +50,9 @@ export interface DownloadResult {
   status: 'success' | 'error' | 'cancelled';
   /** YouTube metadata */
   metadata?: YouTubeMetadata;
-  /** Local video file path (if successful) */
+  /** @internal - Local video file path, not exposed via API */
   videoPath?: string;
-  /** Local thumbnail file path (if generated) */
+  /** @internal - Local thumbnail file path, not exposed via API */
   thumbnailPath?: string;
   /** Error message (if failed) */
   error?: string;


### PR DESCRIPTION
## Summary

The backend API was exposing absolute filesystem paths in JSON responses, leaking the server's directory structure (username, home path, project layout) to any API client.

## Root Cause

No transformation layer existed between the internal storage representation (absolute paths) and the API response boundary. `VideoFile.path` and `DownloadResult.videoPath`/`thumbnailPath` stored and returned absolute filesystem paths directly.

## Changes

| File | Change |
|------|--------|
| `backend/src/routes/api.ts` | Transform `file.path` to `/api/stream/<filename>` URL in `GET /api/videos` and `GET /api/videos/:id` |
| `backend/src/routes/youtube.ts` | Exclude `videoPath` and `thumbnailPath` from `result` in `GET /api/youtube/queue` and `GET /api/youtube/download/:id/status` |
| `backend/src/types/video.ts` | Add `@internal` JSDoc to `VideoFile.path` to prevent future misuse |
| `backend/src/types/youtube.ts` | Add `@internal` JSDoc to `DownloadResult.videoPath` and `thumbnailPath` |
| `backend/src/__tests__/integration/routes/api.test.ts` | Added test asserting `file.path` is a stream URL, not an absolute path |
| `backend/src/__tests__/integration/routes/youtube.test.ts` | Added test asserting `videoPath`/`thumbnailPath` are absent from queue response |

## Testing

- [x] TypeScript build passes
- [x] 22 backend test suites pass (227 tests)
- [x] 14 frontend test suites pass (164 tests)
- [x] Lint passes
- [x] New tests verify paths are transformed/excluded

## Validation

```bash
cd backend && npm run build
cd backend && npm run test -- --testPathPattern="api.test|youtube.test"
cd backend && npm run lint
```

## Issue

Fixes #221

---

<details>
<summary>📋 Implementation Details</summary>

### Implementation followed artifact:

Investigation comment on issue #221

### Deviations from plan:

- Removed now-unused `QueueItem` import from `youtube.ts` (minor cleanup triggered by TypeScript unused-import error)

</details>

---

_Automated implementation from investigation artifact_