### PR TITLE
Chore: Ignore e2e-screenshots directory in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,6 +140,7 @@ vite.config.ts.timestamp-*
 
 # Sofathek specific ignores
 screenshots/*.png
+e2e-screenshots/
 dev/mock-api/*.log
 backend/backend.log
 backend/logs/


### PR DESCRIPTION
## Problem
The `e2e-screenshots/` directory is generated by Playwright E2E tests but was not covered by `.gitignore`. Screenshots were previously removed from the repo (commit `48f4332: fix: Removed screenshots`), yet the gitignore pattern `screenshots/*.png` only covered the `screenshots/` subdirectory — leaving `e2e-screenshots/` untracked and accumulating after each test run.

## Solution
Add `e2e-screenshots/` to the Sofathek-specific section of `.gitignore`, consistent with existing test artifact exclusions such as `playwright-report/`, `test-results/`, and `playwright-videos/`.

## Changes
- `.gitignore`: Added `e2e-screenshots/` under the Sofathek-specific ignores section

## Testing
- All 228 backend tests passed (verified via pre-commit hook)
- All 164 frontend tests passed (verified via pre-commit hook)
- `git status` confirms `e2e-screenshots/` is now fully ignored after the change

## Notes
This is a pure housekeeping fix with no functional impact. E2E screenshots are transient test output and should not be versioned.