### PR TITLE
Fix: strip UUID suffix from video title in extractMetadata (#219)

### DIFF
--- a/backend/src/__tests__/unit/services/videoService.test.ts
+++ b/backend/src/__tests__/unit/services/videoService.test.ts
@@ -307,6 +307,68 @@ describe('VideoService', () => {
     });
   });
 
+  describe('extractMetadata - UUID filename handling', () => {
+    it('should strip UUID suffix from video title', async () => {
+      mockFs.stat.mockResolvedValue({
+        isFile: () => true,
+        size: 1000000,
+        mtime: new Date('2024-01-01')
+      } as any);
+
+      const metadata = await videoService.getVideoMetadata('Unknown_Title-24a69609-5e99-44ed-ac38-42254753105e.mp4');
+
+      expect(metadata?.title).toBe('Unknown Title');
+    });
+
+    it('should handle uppercase UUID suffix', async () => {
+      mockFs.stat.mockResolvedValue({
+        isFile: () => true,
+        size: 1000000,
+        mtime: new Date('2024-01-01')
+      } as any);
+
+      const metadata = await videoService.getVideoMetadata('Unknown_Title-24A69609-5E99-44ED-AC38-42254753105E.mp4');
+
+      expect(metadata?.title).toBe('Unknown Title');
+    });
+
+    it('should handle mixed case UUID suffix', async () => {
+      mockFs.stat.mockResolvedValue({
+        isFile: () => true,
+        size: 1000000,
+        mtime: new Date('2024-01-01')
+      } as any);
+
+      const metadata = await videoService.getVideoMetadata('Unknown_Title-24a69609-5E99-44ed-Ac38-42254753105e.mp4');
+
+      expect(metadata?.title).toBe('Unknown Title');
+    });
+
+    it('should not affect normal titles without UUID', async () => {
+      mockFs.stat.mockResolvedValue({
+        isFile: () => true,
+        size: 1000000,
+        mtime: new Date('2024-01-01')
+      } as any);
+
+      const metadata = await videoService.getVideoMetadata('My_Video_File.mp4');
+
+      expect(metadata?.title).toBe('My Video File');
+    });
+
+    it('should handle multiple UUID segments in filename', async () => {
+      mockFs.stat.mockResolvedValue({
+        isFile: () => true,
+        size: 1000000,
+        mtime: new Date('2024-01-01')
+      } as any);
+
+      const metadata = await videoService.getVideoMetadata('Test-24a69609-5e99-44ed-ac38-42254753105e-video-12345678-abcd-5678-def0-123456789abc.mp4');
+
+      expect(metadata?.title).toBe('Test Video');
+    });
+  });
+
   describe('getVideoFilePath', () => {
     it('should return correct file path', async () => {
       const filePath = videoService.getVideoFilePath('test.mp4');

--- a/backend/src/services/videoService.ts
+++ b/backend/src/services/videoService.ts
@@ -175,8 +175,10 @@ export class VideoService {
     const nameWithoutExt = path.basename(videoFile.name, path.extname(videoFile.name));
     
     const title = nameWithoutExt
+      .replace(/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/gi, ' ')
       .replace(/[-_]/g, ' ')
       .replace(/\b\w/g, char => char.toUpperCase())
+      .replace(/\s+/g, ' ')
       .trim();
 
     // Check for existing thumbnail (jpg, jpeg, png, webp)


### PR DESCRIPTION
## Summary

Videos saved with UUID-based filenames (e.g. `Unknown_Title-24a69609-5e99-44ed-ac38-42254753105e.mp4`) caused the title humanizer to render UUID hex segments as display words, resulting in titles like `Unknown Title 24a69609 5e99 44ed Ac38 42254753105e`.

## Root Cause

The `extractMetadata` method in `videoService.ts` naively replaced all `-` and `_` with spaces and title-cased every word. When yt-dlp metadata extraction fails, filenames are created with a UUID suffix (generated in `youTubeMetadataExtractor.ts` as a fallback ID). The humanizer had no awareness of UUID patterns, so all UUID hex segments were promoted to display words.

## Changes

| File | Change |
|------|--------|
| `backend/src/services/videoService.ts` | Strip UUID pattern before humanizing; collapse extra spaces with `\s+` |
| `backend/src/__tests__/unit/services/videoService.test.ts` | Added 5 tests for UUID filename title extraction |

## Testing

- [x] Type check passes
- [x] Unit tests pass (41/41 in videoService, 242 total)
- [x] Frontend tests pass (164/164)
- [x] Lint passes

## Validation

```bash
# Type check
cd backend && npm run type-check

# Unit tests
cd backend && npm test -- --testPathPattern="videoService.test.ts"

# Lint
cd backend && npm run lint
```

## Issue

Fixes #219

---

<details>
<summary>📋 Implementation Details</summary>

### Implementation followed artifact:

`.ghar/issues/issue-219.md` (investigation comment on issue #219)

### Deviations from plan:

None – implemented exactly as specified in the investigation artifact.

</details>

---

_Automated implementation from investigation artifact_