### PR TITLE
Fix: Sanitize yt-dlp error messages to prevent information disclosure (#218)

### DIFF
--- a/backend/src/__tests__/unit/services/youTubeMetadataExtractor.test.ts
+++ b/backend/src/__tests__/unit/services/youTubeMetadataExtractor.test.ts
@@ -95,16 +95,29 @@ describe('YouTubeMetadataExtractor', () => {
       mockExec.mockReturnValue(mockSubprocess);
 
       await expect(extractor.extract('https://www.youtube.com/watch?v=test'))
-        .rejects.toThrow('Failed to get video metadata: yt-dlp returned empty stdout');
+        .rejects.toThrow('Could not fetch video metadata. Please check the URL and try again.');
     });
 
-    it('should handle extraction errors', async () => {
+    it('should throw sanitized error without internal details on extraction failure', async () => {
       const mockSubprocess = Promise.reject(new Error('Download failed'));
       (mockSubprocess as any).stderr = { on: jest.fn() };
       mockExec.mockReturnValue(mockSubprocess);
 
       await expect(extractor.extract('https://www.youtube.com/watch?v=invalid'))
-        .rejects.toThrow('Failed to get video metadata');
+        .rejects.toThrow('Could not fetch video metadata. Please check the URL and try again.');
+    });
+
+    it('should not expose stderr content in error message', async () => {
+      const internalError = new Error(
+        'The command spawned as:\n  `/home/user/node_modules/yt-dlp ...` exited with: { code: 1 }\n(stderr: ERROR: Unable to download webpage: HTTP Error 404: Not Found)'
+      );
+      const mockSubprocess = Promise.reject(internalError);
+      (mockSubprocess as any).stderr = { on: jest.fn() };
+      mockExec.mockReturnValue(mockSubprocess);
+
+      const rejection = extractor.extract('https://www.youtube.com/watch?v=invalid');
+      await expect(rejection).rejects.toThrow('Could not fetch video metadata');
+      await expect(extractor.extract('https://www.youtube.com/watch?v=invalid')).rejects.not.toThrow('node_modules');
     });
 
     it('should use channel as uploader fallback', async () => {

--- a/backend/src/services/youTubeMetadataExtractor.ts
+++ b/backend/src/services/youTubeMetadataExtractor.ts
@@ -56,12 +56,14 @@ export class YouTubeMetadataExtractor {
     } catch (error) {
       const errorMessage = getErrorMessage(error);
       const stderrMessage = stderrOutput.trim();
-      const detailedMessage = stderrMessage
-        ? `${errorMessage || 'yt-dlp metadata fetch failed'} (stderr: ${stderrMessage})`
-        : errorMessage;
 
-      logger.error('Failed to get video metadata', { url, error: detailedMessage });
-      throw new AppError(`Failed to get video metadata: ${detailedMessage}`, 500);
+      logger.error('Failed to get video metadata', {
+        url,
+        error: errorMessage,
+        stderr: stderrMessage
+      });
+
+      throw new AppError('Could not fetch video metadata. Please check the URL and try again.', 500);
     }
   }
 }


### PR DESCRIPTION
## Summary

When yt-dlp fails (e.g., invalid URL, 404 error), the raw stderr output containing the full filesystem path to the yt-dlp binary and complete CLI command was surfaced verbatim to users via the API error response, constituting an information disclosure vulnerability.

## Root Cause

`YouTubeMetadataExtractor.extract()` concatenated stderr output (which contains the full yt-dlp CLI invocation and filesystem paths) directly into the `AppError` message thrown to users. The `detailedMessage` was built from raw stderr and then passed as the user-visible error string.

## Changes

| File | Change |
|------|--------|
| `backend/src/services/youTubeMetadataExtractor.ts` | Log full error details server-side only; throw generic sanitized user-facing message |
| `backend/src/__tests__/unit/services/youTubeMetadataExtractor.test.ts` | Updated test to verify sanitized message; added test ensuring stderr and internal paths are not exposed |

## Testing

- [x] Type check passes
- [x] Unit tests pass (6/6 in youTubeMetadataExtractor, 243/243 backend total)
- [x] Frontend tests pass (164/164)
- [x] Lint passes
- [x] Pre-push hooks pass (lint, type-check, build)

## Validation

```bash
cd backend && npm run type-check
npm test -- --testPathPattern="youTubeMetadataExtractor"
npm run lint
```

## Issue

Fixes #218

---

<details>
<summary>📋 Implementation Details</summary>

### Implementation followed artifact:

Investigation comment on issue #218

### Deviations from plan:

- The "empty stdout" test case was also updated to expect the new sanitized message (`Could not fetch video metadata. Please check the URL and try again.`) since the empty-stdout `AppError` is also caught by the same catch block and re-thrown with the new generic message. This was a minor but necessary adjustment for test correctness.
- The "should not expose stderr content" test was simplified to use a Promise.reject with an error containing internal path details in the message itself (rather than via the stderr stream mechanism), which is the more realistic failure mode from `youtube-dl-exec`.

</details>

---

_Automated implementation from investigation artifact_