### PR TITLE
Fix: Sanitize yt-dlp error messages in youTubeFileDownloader (#227)

### DIFF
--- a/backend/src/__tests__/unit/services/youTubeFileDownloader.test.ts
+++ b/backend/src/__tests__/unit/services/youTubeFileDownloader.test.ts
@@ -48,7 +48,7 @@ describe('YouTubeFileDownloader', () => {
       );
     });
 
-    it('should handle download failures', async () => {
+    it('should handle download failures with sanitized message', async () => {
       const metadata = {
         id: 'test123',
         title: 'Test Video'
@@ -59,7 +59,30 @@ describe('YouTubeFileDownloader', () => {
       mockExec.mockReturnValue(mockSubprocess);
 
       await expect(downloader.download('https://www.youtube.com/watch?v=test123', metadata))
-        .rejects.toThrow('Failed to download video file');
+        .rejects.toThrow('Could not download video file. Please try again.');
+    });
+
+    it('should not expose internal paths or CLI arguments in error', async () => {
+      const metadata = {
+        id: 'test123',
+        title: 'Test Video'
+      };
+
+      const internalPath = '/home/app/node_modules/yt-dlp/yt_dlp/__main__.py';
+      const mockError = new Error(`yt-dlp failed: ${internalPath} --no-warnings`);
+      const mockSubprocess = Promise.reject(mockError);
+      (mockSubprocess as any).stdout = { on: jest.fn() };
+      mockExec.mockReturnValue(mockSubprocess);
+
+      try {
+        await downloader.download('https://www.youtube.com/watch?v=test123', metadata);
+        fail('Expected error to be thrown');
+      } catch (error: any) {
+        expect(error.message).toBe('Could not download video file. Please try again.');
+        expect(error.message).not.toContain('/home/app');
+        expect(error.message).not.toContain('node_modules');
+        expect(error.message).not.toContain('yt-dlp');
+      }
     });
 
     it('should handle missing downloaded file', async () => {

--- a/backend/src/services/youTubeFileDownloader.ts
+++ b/backend/src/services/youTubeFileDownloader.ts
@@ -74,9 +74,16 @@ export class YouTubeFileDownloader {
       return downloadedPath;
 
     } catch (error) {
+      if (error instanceof AppError) {
+        throw error;
+      }
       const errorMessage = getErrorMessage(error);
-      logger.error('Video file download failed', { url, error: errorMessage });
-      throw new AppError(`Failed to download video file: ${errorMessage}`, 500);
+      logger.error('Video file download failed', {
+        url,
+        error: errorMessage,
+        stderr: (error as any).stderr
+      });
+      throw new AppError('Could not download video file. Please try again.', 500);
     }
   }
 


### PR DESCRIPTION
## Summary

Raw error messages from `youtube-dl-exec` were passed directly to API clients in `youTubeFileDownloader.ts`, potentially exposing absolute filesystem paths (e.g. `/home/app/node_modules/yt-dlp/...`) and full CLI invocations that aid reconnaissance attacks.

## Root Cause

The catch block at `youTubeFileDownloader.ts:76-80` extracted the raw error message and included it verbatim in the `AppError` thrown to users — the same vulnerability class fixed for `youTubeMetadataExtractor.ts` in PR #226.

## Changes

| File | Change |
|------|--------|
| `backend/src/services/youTubeFileDownloader.ts` | Re-throw `AppError` instances unchanged; for raw external errors: log full details (including `stderr`) server-side, throw generic sanitized message to users |
| `backend/src/__tests__/unit/services/youTubeFileDownloader.test.ts` | Updated test to expect sanitized message; added adversarial test verifying internal paths/CLI args never appear in error |

## Testing

- [x] Type check passes
- [x] Unit tests pass (8/8 — including 2 new/updated security tests)
- [x] All 243 backend tests pass
- [x] All 164 frontend tests pass
- [x] Lint passes

## Validation

```bash
cd backend && npm run type-check
npm test -- --testPathPattern="youTubeFileDownloader"
npm run lint
```

## Issue

Fixes #227

---

<details>
<summary>📋 Implementation Details</summary>

### Deviation from artifact plan

The artifact's Step 1 did not account for `AppError` instances thrown inside the `try` block (e.g. `'Downloaded video file not found'` at line 65) being caught and re-wrapped with the generic message. Added an `instanceof AppError` guard to re-throw already-safe errors unchanged, preserving correct error semantics while still sanitizing raw external tool errors.

This is an improvement over the pattern in PR #226 (`youTubeMetadataExtractor.ts`) which has no internal `AppError` throws to worry about.

</details>

---

_Automated implementation from investigation artifact_