### PR TITLE
Simplify video grid and player to title-only presentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A self-hosted family media center application with Netflix-like interface and br
 - **Multi-Site Video Download**: Download videos from YouTube, Vimeo, Twitter/X, and 1000+ other sites via yt-dlp with automatic library integration
 - **Media Library**: File system-based video discovery with thumbnail generation
 - **Video Streaming**: HTTP range request support for efficient video playback
+- **Minimal Video UI**: Grid cards and player view show only the video title and thumbnail/video content (no extra metadata clutter)
 - **Usage Statistics**: Simple view count tracking stored in JSON files
 - **Admin Interface**: Video download management (URL input, queue control), delete videos, storage usage
 - **Mobile-Responsive**: Optimized for all screen sizes

--- a/frontend/src/__tests__/VideoCard.test.tsx
+++ b/frontend/src/__tests__/VideoCard.test.tsx
@@ -5,8 +5,6 @@ import { Video } from '../types';
 
 // Mock the API service
 vi.mock('../services/api', () => ({
-  formatFileSize: vi.fn((size) => `${size} bytes`),
-  formatDuration: vi.fn((duration) => `${duration}s`),
   getVideoThumbnailUrl: vi.fn(() => null)
 }));
 
@@ -61,21 +59,18 @@ describe('VideoCard Component', () => {
     expect(mockOnClick).toHaveBeenCalledWith(mockVideo);
   });
 
-  test('should show metadata by default', () => {
-    render(<VideoCard video={mockVideo} />);
-
-    const metadata = screen.getByTestId('video-metadata');
-    expect(metadata).toBeDefined();
-    expect(metadata.textContent).toContain('test-video.mp4');
-    expect(metadata.textContent).toContain('1024000 bytes');
-  });
-
   test('should not show metadata when showMetadata is false', () => {
     render(<VideoCard video={mockVideo} showMetadata={false} />);
 
     const title = screen.getByTestId('video-title');
     expect(title).toBeDefined();
     
+    const metadata = screen.queryByTestId('video-metadata');
+    expect(metadata).toBeNull();
+  });
+
+  test('should not show metadata by default', () => {
+    render(<VideoCard video={mockVideo} />);
     const metadata = screen.queryByTestId('video-metadata');
     expect(metadata).toBeNull();
   });
@@ -108,9 +103,8 @@ describe('VideoCard Component', () => {
     const title = screen.getByTestId('video-title');
     expect(title.textContent).toBe('Minimal Video');
     
-    const metadata = screen.getByTestId('video-metadata');
-    expect(metadata.textContent).toContain('minimal.mp4');
-    expect(metadata.textContent).toContain('500 bytes');
+    const metadata = screen.queryByTestId('video-metadata');
+    expect(metadata).toBeNull();
   });
 
   test('should have proper CSS classes for interactivity', () => {
@@ -142,22 +136,14 @@ describe('VideoCard accessibility', () => {
     lastViewed: new Date('2024-01-15T12:00:00Z')
   };
 
-  test('should have sufficient color contrast for metadata text', () => {
+  test('should avoid rendering metadata text for simplified cards', () => {
     render(<VideoCard video={mockVideo} />);
-    const metadata = screen.getByTestId('video-metadata');
-    const computedStyle = window.getComputedStyle(metadata);
-    
-    // Verify color is using CSS variable (not hardcoded)
-    expect(computedStyle.color).not.toBe('rgb(107, 114, 126)'); // text-slate-500
-    expect(computedStyle.color).not.toBe('#666');
+    const metadata = screen.queryByTestId('video-metadata');
+    expect(metadata).toBeNull();
   });
 
-  test('should use theme-aware colors', () => {
+  test('should keep title accessible', () => {
     render(<VideoCard video={mockVideo} />);
-    const metadata = screen.getByTestId('video-metadata');
-    
-    // Should use CSS custom property
-    expect(metadata.className).not.toContain('text-slate-500');
-    expect(metadata.className).not.toContain('text-gray-600');
+    expect(screen.getByTestId('video-title').textContent).toBe('Test Video Title');
   });
 });

--- a/frontend/src/__tests__/VideoPlayer.test.tsx
+++ b/frontend/src/__tests__/VideoPlayer.test.tsx
@@ -144,7 +144,7 @@ describe('VideoPlayer Component - Malformed Data Handling', () => {
     expect(() => render(<VideoPlayer video={partialVideo} />)).not.toThrow();
   });
 
-  test('should show Unknown format when metadata format and file extension are missing', () => {
+  test('should not render header metadata details', () => {
     const malformedVideo = {
       id: 'test-video',
       file: {
@@ -165,20 +165,18 @@ describe('VideoPlayer Component - Malformed Data Handling', () => {
 
     render(<VideoPlayer video={malformedVideo} />);
 
-    const formatLabel = screen.getByText('Format:');
-    const formatRow = formatLabel.closest('.metadata-item');
-    expect(formatRow?.textContent).toContain('Unknown');
+    expect(document.querySelector('.video-info')).toBeNull();
   });
 
-  test('should hide file metadata rows when optional file properties are missing', () => {
+  test('should not render file metadata section', () => {
     const malformedVideo = {
       id: 'test-video',
       file: {
         name: 'test.mp4',
-        size: undefined,
+        size: 1024000,
         path: '/videos/test.mp4',
         extension: 'mp4',
-        lastModified: undefined
+        lastModified: new Date()
       },
       metadata: {
         title: 'Test Video',
@@ -191,6 +189,7 @@ describe('VideoPlayer Component - Malformed Data Handling', () => {
     render(<VideoPlayer video={malformedVideo} />);
 
     expect(screen.queryByText('File Size:')).toBeNull();
+    expect(screen.queryByText('Format:')).toBeNull();
     expect(screen.queryByText('Last Modified:')).toBeNull();
   });
 });

--- a/frontend/src/components/VideoCard/VideoCard.tsx
+++ b/frontend/src/components/VideoCard/VideoCard.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { VideoCardProps } from '../../types';
-import { Card, CardDescription, CardHeader, CardTitle } from '../ui/card';
-import { formatDuration, formatFileSize, getVideoThumbnailUrl } from '../../services/api';
+import { Card, CardHeader, CardTitle } from '../ui/card';
+import { getVideoThumbnailUrl } from '../../services/api';
 
 export function VideoCard({ 
   video, 
@@ -9,6 +9,7 @@ export function VideoCard({
   showMetadata = true, 
   className = '' 
 }: VideoCardProps) {
+  void showMetadata;
   const thumbnailUrl = getVideoThumbnailUrl(video);
   
   const handleClick = () => {
@@ -43,12 +44,6 @@ export function VideoCard({
           </div>
         )}
         
-        {/* Duration overlay */}
-        {video.metadata.duration && (
-          <div className="duration-overlay">
-            {formatDuration(video.metadata.duration)}
-          </div>
-        )}
       </div>
 
       {/* Video Information */}
@@ -56,25 +51,6 @@ export function VideoCard({
         <CardTitle className="video-title" data-testid="video-title">
           {video.metadata.title}
         </CardTitle>
-        
-        {showMetadata && (
-          <CardDescription className="video-metadata" data-testid="video-metadata">
-            <div className="metadata-row">
-              <span>File: {video.file.name}</span>
-            </div>
-            <div className="metadata-row">
-              <span>Size: {formatFileSize(video.file.size)}</span>
-              {video.metadata.width && video.metadata.height && (
-                <span> • {video.metadata.width}×{video.metadata.height}</span>
-              )}
-            </div>
-            {video.lastViewed && (
-              <div className="metadata-row">
-                <span>Last viewed: {video.lastViewed.toString().split('T')[0]}</span>
-              </div>
-            )}
-          </CardDescription>
-        )}
       </CardHeader>
     </Card>
   );

--- a/frontend/src/components/VideoPlayer/VideoPlayer.tsx
+++ b/frontend/src/components/VideoPlayer/VideoPlayer.tsx
@@ -81,16 +81,10 @@ export function VideoPlayer({
   const videoFileName = video.file?.name;
   const hasValidFile = Boolean(videoFileName);
   const streamingUrl = videoFileName ? getVideoStreamUrl(videoFileName) : '';
-  const formatText = video.metadata.format || video.file?.extension?.toUpperCase() || 'Unknown';
-
   return (
     <div className={`video-player ${className}`}>
       <div className="video-header">
         <h2 className="video-player-title">{video.metadata.title}</h2>
-        <div className="video-info">
-          <span className="video-resolution">{video.metadata.width}x{video.metadata.height}</span>
-          <span className="video-duration">{video.metadata.duration ? `${Math.floor(video.metadata.duration / 60)}:${(video.metadata.duration % 60).toString().padStart(2, '0')}` : 'Unknown'}</span>
-        </div>
       </div>
 
       <div className="video-container">
@@ -163,24 +157,6 @@ export function VideoPlayer({
         )}
       </div>
 
-      <div className="video-metadata">
-        {video.file?.size !== undefined && (
-          <div className="metadata-item">
-            <span className="metadata-label">File Size:</span>
-            <span className="metadata-value">{(video.file.size / (1024 * 1024)).toFixed(1)} MB</span>
-          </div>
-        )}
-        <div className="metadata-item">
-          <span className="metadata-label">Format:</span>
-          <span className="metadata-value">{formatText}</span>
-        </div>
-        {video.file?.lastModified && (
-          <div className="metadata-item">
-            <span className="metadata-label">Last Modified:</span>
-            <span className="metadata-value">{new Date(video.file.lastModified).toLocaleDateString()}</span>
-          </div>
-        )}
-      </div>
     </div>
   );
 }


### PR DESCRIPTION
### Motivation
- The UI should not surface video metadata in the grid or player views, showing only the title and thumbnail/video to reduce clutter.
- Tests and documentation should reflect the simplified presentation to ensure consistency across the frontend.

### Description
- Remove metadata rendering and helpers from grid cards by updating `frontend/src/components/VideoCard/VideoCard.tsx` to render only the thumbnail and title and by removing imports for `formatDuration`/`formatFileSize`.
- Remove header metadata and the file metadata block from the player by updating `frontend/src/components/VideoPlayer/VideoPlayer.tsx` to leave only the title and playback UI.
- Update unit tests in `frontend/src/__tests__/VideoCard.test.tsx` and `frontend/src/__tests__/VideoPlayer.test.tsx` to assert that metadata elements are not rendered while preserving title and interaction checks.
- Document the change in the features list by updating `README.md` to mention the minimal video UI behavior.

### Testing
- Ran `npm run --prefix frontend test -- VideoCard.test.tsx VideoPlayer.test.tsx` and the test run completed with all tests passing (`Tests 164 passed`).
- Ran `npm run --prefix frontend lint` and the linter completed without blocking warnings.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4c9e61d2c8332bf1a1a03e53892df)