### PR TITLE
Add clear-queue control in frontend and API support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A self-hosted family media center application with Netflix-like interface and br
 - **Media Library**: File system-based video discovery with thumbnail generation
 - **Video Streaming**: HTTP range request support for efficient video playback
 - **Usage Statistics**: Simple view count tracking stored in JSON files
-- **Admin Interface**: Video download management (URL input, queue control), delete videos, storage usage
+- **Admin Interface**: Video download management (URL input, queue control, clear queue action), delete videos, storage usage
 - **Mobile-Responsive**: Optimized for all screen sizes
 
 ## Tech Stack

--- a/backend/src/__tests__/integration/routes/youtube.test.ts
+++ b/backend/src/__tests__/integration/routes/youtube.test.ts
@@ -10,7 +10,8 @@ jest.mock('../../../services/index', () => ({
     addToQueue: jest.fn(),
     getQueueStatus: jest.fn(),
     cancelDownload: jest.fn(),
-    cleanupOldItems: jest.fn()
+    cleanupOldItems: jest.fn(),
+    clearQueue: jest.fn()
   },
   youTubeDownloadService: {
     validateYouTubeUrl: jest.fn()
@@ -347,6 +348,24 @@ describe('YouTube Routes', () => {
       expect(response.body.data.cleanedCount).toBe(5);
       expect(response.body.data.maxAgeHours).toBe(48);
       expect(mockDownloadQueueService.cleanupOldItems).toHaveBeenCalledWith(48);
+    });
+  });
+
+  describe('DELETE /api/youtube/queue', () => {
+    it('should clear queue and return summary', async () => {
+      mockDownloadQueueService.clearQueue.mockResolvedValue({
+        removedCount: 4,
+        cancelledProcessingCount: 1
+      });
+
+      const response = await request(app)
+        .delete('/api/youtube/queue');
+
+      expect(response.status).toBe(200);
+      expect(response.body.status).toBe('success');
+      expect(response.body.data.removedCount).toBe(4);
+      expect(response.body.data.cancelledProcessingCount).toBe(1);
+      expect(mockDownloadQueueService.clearQueue).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/backend/src/routes/youtube.ts
+++ b/backend/src/routes/youtube.ts
@@ -221,6 +221,24 @@ router.post('/queue/cleanup', catchAsync(async (req: Request, res: Response) => 
 }));
 
 /**
+ * DELETE /api/youtube/queue
+ * Clear all queue items and stop active downloads
+ */
+router.delete('/queue', catchAsync(async (_req: Request, res: Response) => {
+  logger.info('Queue clear request');
+  const result = await downloadQueueService.clearQueue();
+
+  res.json({
+    status: 'success',
+    data: {
+      message: `Cleared ${result.removedCount} queue items`,
+      removedCount: result.removedCount,
+      cancelledProcessingCount: result.cancelledProcessingCount
+    }
+  });
+}));
+
+/**
  * GET /api/youtube/health
  * Health check endpoint for YouTube integration
  */

--- a/backend/src/services/downloadQueueService.ts
+++ b/backend/src/services/downloadQueueService.ts
@@ -14,6 +14,11 @@ interface CancelResult {
   reason?: 'not_found' | 'already_completed' | 'already_cancelled' | 'error';
 }
 
+interface ClearQueueResult {
+  removedCount: number;
+  cancelledProcessingCount: number;
+}
+
 /**
  * Queue management for YouTube download operations
  */
@@ -254,5 +259,51 @@ export class DownloadQueueService {
       });
       return 0;
     }
+  }
+
+  /**
+   * Clear all queue items and cancel any active downloads.
+   */
+  async clearQueue(): Promise<ClearQueueResult> {
+    const snapshot = [...this.queue];
+    let cancelledProcessingCount = 0;
+
+    for (const item of snapshot) {
+      if (item.status === 'processing') {
+        try {
+          await this.youtubeDownloadService.cancelDownload(item.id);
+          cancelledProcessingCount += 1;
+        } catch (error) {
+          logger.warn('Failed to cancel active download while clearing queue', {
+            queueItemId: item.id,
+            error: getErrorMessage(error)
+          });
+        }
+      }
+
+      if (item.result?.videoPath) {
+        try {
+          await fs.unlink(item.result.videoPath);
+        } catch (error) {
+          logger.warn('Failed to remove queue item file while clearing queue', {
+            queueItemId: item.id,
+            error: getErrorMessage(error)
+          });
+        }
+      }
+    }
+
+    this.queue = [];
+    await this.saveQueue();
+
+    logger.info('Queue cleared', {
+      removedCount: snapshot.length,
+      cancelledProcessingCount
+    });
+
+    return {
+      removedCount: snapshot.length,
+      cancelledProcessingCount
+    };
   }
 }

--- a/frontend/src/__tests__/DownloadQueue.test.tsx
+++ b/frontend/src/__tests__/DownloadQueue.test.tsx
@@ -3,17 +3,19 @@ import { describe, test, expect, beforeEach, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { DownloadQueue } from '../components/DownloadQueue';
-import { useDownloadQueue, useCancelDownload } from '../hooks/useYouTube';
+import { useDownloadQueue, useCancelDownload, useClearDownloadQueue } from '../hooks/useYouTube';
 import { QueueStatus } from '../types/youtube';
 
 // Mock the YouTube hooks
 vi.mock('../hooks/useYouTube', () => ({
   useDownloadQueue: vi.fn(),
   useCancelDownload: vi.fn(),
+  useClearDownloadQueue: vi.fn(),
 }));
 
 const mockUseDownloadQueue = vi.mocked(useDownloadQueue);
 const mockUseCancelDownload = vi.mocked(useCancelDownload);
+const mockUseClearDownloadQueue = vi.mocked(useClearDownloadQueue);
 
 // Test wrapper for React Query
 const createWrapper = () => {
@@ -34,6 +36,16 @@ describe('DownloadQueue Component', () => {
     
     // Default mock for cancel mutation
     mockUseCancelDownload.mockReturnValue({
+      mutate: vi.fn(),
+      isPending: false,
+      isError: false,
+      isSuccess: false,
+      error: null,
+      data: undefined,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    mockUseClearDownloadQueue.mockReturnValue({
       mutate: vi.fn(),
       isPending: false,
       isError: false,
@@ -77,6 +89,7 @@ describe('DownloadQueue Component', () => {
     expect(screen.getByText('Download Queue')).toBeInTheDocument();
     expect(screen.getByText('No downloads yet')).toBeInTheDocument();
     expect(screen.getByText(/enter a youtube url above to start downloading/i)).toBeInTheDocument();
+    expect(screen.getByTestId('clear-queue-button')).toBeDisabled();
   });
 
   test('should render loading state', () => {
@@ -417,5 +430,60 @@ describe('DownloadQueue Component', () => {
 
     const component = screen.getByTestId('download-queue');
     expect(component).toHaveClass('custom-queue-class');
+  });
+
+  test('should clear queue when clear button is confirmed', () => {
+    const mockClearMutate = vi.fn();
+    mockUseClearDownloadQueue.mockReturnValue({
+      mutate: mockClearMutate,
+      isPending: false,
+      isError: false,
+      isSuccess: false,
+      error: null,
+      data: undefined,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    const queueWithItems: QueueStatus = {
+      items: [
+        {
+          id: 'download-1',
+          url: 'https://www.youtube.com/watch?v=test1',
+          title: 'Queued Video',
+          status: 'pending',
+          progress: 0,
+          currentStep: 'Queued',
+          queuedAt: new Date().toISOString()
+        }
+      ],
+      totalItems: 1,
+      processing: 0,
+      completed: 0,
+      failed: 0,
+      pending: 1,
+      cancelled: 0,
+      lastUpdated: new Date().toISOString()
+    };
+
+    mockUseDownloadQueue.mockReturnValue({
+      data: queueWithItems,
+      isLoading: false,
+      error: null,
+      isError: false,
+      refetch: vi.fn()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+
+    const Wrapper = createWrapper();
+    render(
+      <Wrapper>
+        <DownloadQueue />
+      </Wrapper>
+    );
+
+    fireEvent.click(screen.getByTestId('clear-queue-button'));
+    expect(mockClearMutate).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/components/DownloadQueue.tsx
+++ b/frontend/src/components/DownloadQueue.tsx
@@ -3,7 +3,7 @@ import { getUserFriendlyErrorMessage } from '../lib/error';
 import { Card, CardDescription, CardHeader, CardTitle } from './ui/card';
 import { Button } from './ui/button';
 import { Alert, AlertDescription } from './ui/alert';
-import { useDownloadQueue, useCancelDownload } from '../hooks/useYouTube';
+import { useDownloadQueue, useCancelDownload, useClearDownloadQueue } from '../hooks/useYouTube';
 import { QueueItem } from '../types/youtube';
 
 interface DownloadQueueProps {
@@ -143,6 +143,21 @@ function QueueItemComponent({ item, onCancel, className = '' }: QueueItemCompone
 
 export function DownloadQueue({ className = '' }: DownloadQueueProps) {
   const { data: queue, isLoading, error } = useDownloadQueue();
+  const clearQueueMutation = useClearDownloadQueue();
+
+  const handleClearQueue = () => {
+    const hasQueueItems = (queue?.items?.length ?? 0) > 0;
+    if (!hasQueueItems) {
+      return;
+    }
+
+    const confirmed = window.confirm('Clear the full download queue? This will stop active downloads.');
+    if (!confirmed) {
+      return;
+    }
+
+    clearQueueMutation.mutate();
+  };
 
   if (error) {
     return (
@@ -184,7 +199,18 @@ export function DownloadQueue({ className = '' }: DownloadQueueProps) {
   return (
     <Card className={`download-queue ${className}`} data-testid="download-queue">
       <CardHeader>
-        <CardTitle>Download Queue</CardTitle>
+        <div className="flex items-center justify-between gap-3">
+          <CardTitle>Download Queue</CardTitle>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleClearQueue}
+            disabled={clearQueueMutation.isPending || !queue || queue.totalItems === 0}
+            data-testid="clear-queue-button"
+          >
+            {clearQueueMutation.isPending ? 'Clearing...' : 'Clear Queue'}
+          </Button>
+        </div>
         {queue && (
           <CardDescription>
             {queue.totalItems === 0 ? (

--- a/frontend/src/hooks/useYouTube.ts
+++ b/frontend/src/hooks/useYouTube.ts
@@ -3,7 +3,8 @@ import {
   downloadVideo, 
   getDownloadQueue, 
   getDownloadStatus, 
-  cancelDownload 
+  cancelDownload,
+  clearDownloadQueue
 } from '../services/youtube';
 import { DownloadRequest, QueueStatus, QueueItem } from '../types/youtube';
 
@@ -231,4 +232,19 @@ export function useClearQueue() {
     clearAll,
     isClearing: cancelMutation.isPending,
   };
+}
+
+/**
+ * Hook for clearing the full queue
+ */
+export function useClearDownloadQueue() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: clearDownloadQueue,
+    retry: 1,
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ['youtube', 'queue'] });
+    },
+  });
 }

--- a/frontend/src/services/youtube.ts
+++ b/frontend/src/services/youtube.ts
@@ -149,6 +149,22 @@ export async function cancelDownload(itemId: string): Promise<{ message: string;
 }
 
 /**
+ * Clear the entire download queue
+ * DELETE /api/youtube/queue
+ */
+export async function clearDownloadQueue(): Promise<{ message: string; removedCount: number; cancelledProcessingCount: number }> {
+  const response = await youtubeApiFetch<{ message: string; removedCount: number; cancelledProcessingCount: number }>('/youtube/queue', {
+    method: 'DELETE',
+  });
+
+  if (response.status !== 'success' || !response.data) {
+    throw new ApiError(response.message || 'Failed to clear download queue', 400);
+  }
+
+  return response.data;
+}
+
+/**
  * Validate video URL format (supports YouTube and other video URLs)
  * Matches backend validation logic for consistency
  */


### PR DESCRIPTION
### Motivation

- Provide a user-accessible way in the frontend admin UI to clear the download queue (including stopping active downloads) so administrators can quickly recover or reset queue state.

### Description

- Added a backend service method `DownloadQueueService.clearQueue()` that cancels active processing downloads, attempts to clean up generated files, empties the persisted queue, and returns a summary object.
- Exposed a backend endpoint `DELETE /api/youtube/queue` that invokes `clearQueue()` and returns `removedCount` and `cancelledProcessingCount` in the response.
- Added a frontend API client `clearDownloadQueue()` and a React Query mutation hook `useClearDownloadQueue()` to call the new backend endpoint and refresh queue state.
- Added a `Clear Queue` button in `DownloadQueue` with a confirmation prompt, disabled state when queue is empty or while clearing, and associated unit tests; updated tests and README to cover the new behavior.

### Testing

- ❌ Backend integration tests could not be fully executed because dependency installation failed in this environment, the attempted `npm --prefix backend install` failed during `youtube-dl-exec` postinstall with a network error (`ENETUNREACH`), so `jest` integration runs were not completed (verified at 2026-03-26T05:56:16Z while running `npm --prefix backend install`).
- ✅ Frontend component tests were run with `npm --prefix frontend test -- --run src/__tests__/DownloadQueue.test.tsx` and completed successfully (`Start at 2026-03-26T05:55:23Z`, result: `14 files passed, 165 tests passed`).
- ✅ Frontend lint was run with `npm --prefix frontend run lint` and succeeded with no blocking errors.
- ✅ Frontend production build was run with `npm --prefix frontend run build` and completed successfully producing the `dist/` artifacts.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4c9522ca88332b95e32c70626cc08)