### PR TITLE
fix(queue): keep downloaded files when clearing queue

### DIFF
--- a/backend/src/__tests__/unit/services/downloadQueueService.test.ts
+++ b/backend/src/__tests__/unit/services/downloadQueueService.test.ts
@@ -5,12 +5,14 @@ const mockReadFile = jest.fn();
 const mockWriteFile = jest.fn();
 const mockMkdir = jest.fn();
 const mockRename = jest.fn();
+const mockUnlink = jest.fn();
 
 jest.mock('fs/promises', () => ({
   readFile: (...args: any[]) => mockReadFile(...args),
   writeFile: (...args: any[]) => mockWriteFile(...args),
   mkdir: (...args: any[]) => mockMkdir(...args),
-  rename: (...args: any[]) => mockRename(...args)
+  rename: (...args: any[]) => mockRename(...args),
+  unlink: (...args: any[]) => mockUnlink(...args)
 }));
 
 jest.mock('fs', () => ({
@@ -20,8 +22,10 @@ jest.mock('fs', () => ({
 
 // Mock YouTubeDownloadService
 const mockDownloadVideo = jest.fn();
+const mockCancelDownload = jest.fn();
 const mockYoutubeService = {
-  downloadVideo: mockDownloadVideo
+  downloadVideo: mockDownloadVideo,
+  cancelDownload: mockCancelDownload
 } as any;
 
 describe('DownloadQueueService', () => {
@@ -35,6 +39,8 @@ describe('DownloadQueueService', () => {
     mockWriteFile.mockResolvedValue(undefined);
     mockMkdir.mockResolvedValue(undefined);
     mockRename.mockResolvedValue(undefined);
+    mockUnlink.mockResolvedValue(undefined);
+    mockCancelDownload.mockResolvedValue(undefined);
     
     // Mock YouTube service to return success result
     mockDownloadVideo.mockResolvedValue({
@@ -166,6 +172,78 @@ describe('DownloadQueueService', () => {
       expect(cleanedCount1).toBe(0);
       expect(cleanedCount2).toBe(0); 
       expect(cleanedCount3).toBe(0);
+    });
+  });
+
+  describe('clearQueue', () => {
+    beforeEach(async () => {
+      mockReadFile.mockRejectedValue(new Error('File not found'));
+      mockWriteFile.mockResolvedValue(undefined);
+      await service.initialize();
+    });
+
+    it('should clear queue items and keep downloaded files intact', async () => {
+      const request = {
+        url: 'https://youtu.be/test-video',
+        requestId: 'req-1',
+        requestedAt: new Date()
+      };
+
+      const processingItem = await service.addToQueue(request);
+      const completedItem = await service.addToQueue({
+        ...request,
+        requestId: 'req-2'
+      });
+
+      const status = service.getQueueStatus();
+      const processing = status.items.find(item => item.id === processingItem.id);
+      const completed = status.items.find(item => item.id === completedItem.id);
+
+      if (!processing || !completed) {
+        throw new Error('Expected queue items to exist for test setup');
+      }
+
+      processing.status = 'processing';
+      completed.status = 'completed';
+      completed.result = {
+        id: 'download-1',
+        status: 'success',
+        videoPath: '/downloads/video.mp4',
+        startedAt: new Date(),
+        completedAt: new Date()
+      };
+
+      const result = await service.clearQueue();
+
+      expect(result.removedCount).toBe(2);
+      expect(result.cancelledProcessingCount).toBe(1);
+      expect(mockCancelDownload).toHaveBeenCalledWith(processingItem.id);
+      expect(mockUnlink).not.toHaveBeenCalled();
+      expect(service.getQueueStatus().totalItems).toBe(0);
+    });
+
+    it('should still clear queue if cancelling active downloads fails', async () => {
+      mockCancelDownload.mockRejectedValueOnce(new Error('cancel failed'));
+      const request = {
+        url: 'https://youtu.be/test-video',
+        requestId: 'req-1',
+        requestedAt: new Date()
+      };
+
+      const queueItem = await service.addToQueue(request);
+      const status = service.getQueueStatus();
+      const processing = status.items.find(item => item.id === queueItem.id);
+
+      if (!processing) {
+        throw new Error('Expected queue item to exist for test setup');
+      }
+      processing.status = 'processing';
+
+      const result = await service.clearQueue();
+
+      expect(result.removedCount).toBe(1);
+      expect(result.cancelledProcessingCount).toBe(0);
+      expect(service.getQueueStatus().totalItems).toBe(0);
     });
   });
   

--- a/backend/src/services/downloadQueueService.ts
+++ b/backend/src/services/downloadQueueService.ts
@@ -281,16 +281,6 @@ export class DownloadQueueService {
         }
       }
 
-      if (item.result?.videoPath) {
-        try {
-          await fs.unlink(item.result.videoPath);
-        } catch (error) {
-          logger.warn('Failed to remove queue item file while clearing queue', {
-            queueItemId: item.id,
-            error: getErrorMessage(error)
-          });
-        }
-      }
     }
 
     this.queue = [];


### PR DESCRIPTION
### Motivation
- The `clearQueue()` routine was unlinking downloaded video files when clearing queue entries, causing users to lose completed downloads unexpectedly. This change prevents media removal while still stopping active downloads.

### Description
- Stop deleting downloaded files in `clearQueue()` by removing the `fs.unlink` calls that removed `item.result.videoPath` for each queue item. (`backend/src/services/downloadQueueService.ts`)
- Add unit tests that cover `clearQueue()` behavior to assert that completed downloads are not removed and that processing items are cancelled. (`backend/src/__tests__/unit/services/downloadQueueService.test.ts`)
- Extend test mocks to include `unlink` and `cancelDownload` so tests can verify that file deletion is not invoked and cancellation is attempted for processing items. (`backend/src/__tests__/unit/services/downloadQueueService.test.ts`)

### Testing
- Ran dependency installation with `npm install --ignore-scripts`, which completed successfully in the environment used for tests. (Succeeded)
- Executed the focused unit test suite with `npm run test --workspace=backend -- downloadQueueService.test.ts`, which passed: the test file reported `11 passed` and the suite exited successfully. (Succeeded)
- Ran backend linting with `npm run lint --workspace=backend`, which completed without errors. (Succeeded)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4cf86846483329db02ca3e39f5457)