### PR TITLE
Fix: keep bundled yt-dlp binary up-to-date via postinstall (#238)

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -17,7 +17,8 @@
     "test:integration": "jest src/__tests__/integration",
     "test:real-youtube": "RUN_REAL_DOWNLOAD_TESTS=true jest src/__tests__/integration/routes/youtube.integration.test.ts",
     "test:youtube": "ts-node scripts/youtube-integration.ts",
-    "test:queue": "ts-node scripts/download-queue.ts"
+    "test:queue": "ts-node scripts/download-queue.ts",
+    "postinstall": "node node_modules/youtube-dl-exec/scripts/postinstall.js"
   },
   "dependencies": {
     "cors": "^2.8.5",


### PR DESCRIPTION
## Summary

YouTube downloads fail with \"This video is not available\" because the bundled yt-dlp binary (v2026.03.13) shipped with `youtube-dl-exec` has a bug in its Node.js JavaScript challenge solver (`self.location.origin` is undefined in Node context). The system yt-dlp v2026.03.17 fixes this.

## Root Cause

The `jsRuntimes: 'node'` option was already being **correctly** translated to `--js-runtimes node` by the `dargs` library used by `youtube-dl-exec`. The investigation artifact misidentified the mechanism — the real root cause is the **outdated bundled binary** (v2026.03.13) having a bug in the YouTube n-challenge JavaScript solver, fixed in v2026.03.17.

**Evidence chain:**
- Bundled yt-dlp v2026.03.13 + `--js-runtimes node` → fails: `TypeError: Cannot read properties of undefined (reading 'origin')`
- System yt-dlp v2026.03.17 + `--js-runtimes node` → `SUCCESS: Lavar - Andreas Sandqvist`
- Both are same version string `2026.03.17` for system; bundled was `2026.03.13`

## Changes

| File | Change |
|------|--------|
| `backend/package.json` | Added `postinstall` script that re-runs `youtube-dl-exec`'s own postinstall to always pull the latest yt-dlp binary, preventing version drift |

## Testing

- [x] Type check passes
- [x] Unit tests pass (24/24 suites, 266 tests)
- [x] Lint passes
- [x] Build validation passes
- [x] Manual verification: `yt-dlp --js-runtimes node --dump-json https://www.youtube.com/watch?v=03gAoNcPO1g` → `SUCCESS: Lavar - Andreas Sandqvist`

## Validation

```bash
cd backend && npm run type-check && npm test -- --testPathPattern="youTubeMetadataExtractor|youTubeFileDownloader" && npm run lint
```

## Issue

Fixes #238

---

<details>
<summary>📋 Implementation Details</summary>

### Deviation from investigation artifact

The artifact proposed changing `jsRuntimes: 'node'` to `extraArgs: ['--js-runtimes', 'node']` in both YouTube service files. This change was **not needed** because:

1. `jsRuntimes: 'node'` is a valid typed option in `youtube-dl-exec`'s type definitions
2. `dargs` correctly translates it to `--js-runtimes node` (verified via `node -e "const dargs = require('dargs'); console.log(dargs({jsRuntimes: 'node'}, {useEquals: false}))"` → `['--js-runtimes', 'node', ...]`)
3. The actual failure was the **bundled yt-dlp binary version** (2026.03.13) having a bug, fixed in 2026.03.17

The correct fix is ensuring the bundled binary stays current, achieved by adding a `postinstall` hook.

</details>

---

_Automated implementation from investigation artifact_