### PR TITLE
Auto-refresh video library when downloads complete

### DIFF
--- a/frontend/src/__tests__/DownloadQueue.test.tsx
+++ b/frontend/src/__tests__/DownloadQueue.test.tsx
@@ -432,6 +432,88 @@ describe('DownloadQueue Component', () => {
     expect(component).toHaveClass('custom-queue-class');
   });
 
+  test('should invalidate videos query when a download completes', () => {
+    const queueBeforeCompletion: QueueStatus = {
+      items: [
+        {
+          id: 'download-1',
+          url: 'https://www.youtube.com/watch?v=test1',
+          title: 'Processing Video',
+          status: 'processing',
+          progress: 80,
+          currentStep: 'Downloading',
+          queuedAt: new Date().toISOString(),
+        },
+      ],
+      totalItems: 1,
+      processing: 1,
+      completed: 0,
+      failed: 0,
+      pending: 0,
+      cancelled: 0,
+      lastUpdated: new Date().toISOString(),
+    };
+
+    const queueAfterCompletion: QueueStatus = {
+      ...queueBeforeCompletion,
+      items: [
+        {
+          ...queueBeforeCompletion.items[0],
+          status: 'completed',
+          progress: 100,
+          completedAt: new Date().toISOString(),
+        },
+      ],
+      processing: 0,
+      completed: 1,
+    };
+
+    mockUseDownloadQueue.mockReturnValue({
+      data: queueBeforeCompletion,
+      isLoading: false,
+      error: null,
+      isError: false,
+      refetch: vi.fn(),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const Wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+
+    const { rerender } = render(
+      <Wrapper>
+        <DownloadQueue />
+      </Wrapper>
+    );
+
+    mockUseDownloadQueue.mockReturnValue({
+      data: queueAfterCompletion,
+      isLoading: false,
+      error: null,
+      isError: false,
+      refetch: vi.fn(),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    rerender(
+      <Wrapper>
+        <DownloadQueue />
+      </Wrapper>
+    );
+
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['videos'] });
+  });
+
   test('should clear queue when clear button is confirmed', () => {
     const mockClearMutate = vi.fn();
     mockUseClearDownloadQueue.mockReturnValue({

--- a/frontend/src/components/DownloadQueue.tsx
+++ b/frontend/src/components/DownloadQueue.tsx
@@ -1,9 +1,10 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import { getUserFriendlyErrorMessage } from '../lib/error';
 import { Card, CardDescription, CardHeader, CardTitle } from './ui/card';
 import { Button } from './ui/button';
 import { Alert, AlertDescription } from './ui/alert';
 import { useDownloadQueue, useCancelDownload, useClearDownloadQueue } from '../hooks/useYouTube';
+import { useQueryClient } from '@tanstack/react-query';
 import { QueueItem } from '../types/youtube';
 
 interface DownloadQueueProps {
@@ -144,6 +145,31 @@ function QueueItemComponent({ item, onCancel, className = '' }: QueueItemCompone
 export function DownloadQueue({ className = '' }: DownloadQueueProps) {
   const { data: queue, isLoading, error } = useDownloadQueue();
   const clearQueueMutation = useClearDownloadQueue();
+  const queryClient = useQueryClient();
+  const previousCompletedIdsRef = useRef<Set<string> | null>(null);
+
+  useEffect(() => {
+    const completedIds = new Set(
+      (queue?.items ?? [])
+        .filter((item) => item.status === 'completed')
+        .map((item) => item.id)
+    );
+
+    if (previousCompletedIdsRef.current === null) {
+      previousCompletedIdsRef.current = completedIds;
+      return;
+    }
+
+    const hasNewlyCompletedItem = [...completedIds].some(
+      (id) => !previousCompletedIdsRef.current?.has(id)
+    );
+
+    if (hasNewlyCompletedItem) {
+      queryClient.invalidateQueries({ queryKey: ['videos'] });
+    }
+
+    previousCompletedIdsRef.current = completedIds;
+  }, [queue, queryClient]);
 
   const handleClearQueue = () => {
     const hasQueueItems = (queue?.items?.length ?? 0) > 0;


### PR DESCRIPTION
### Motivation
- The video library currently requires a manual browser refresh after a download finishes, so the UI should refresh automatically when new videos become available.

### Description
- Detect newly completed download items in `DownloadQueue` and call `queryClient.invalidateQueries({ queryKey: ['videos'] })` to refresh the library when a new completion is observed.
- Avoid unnecessary initial invalidation by tracking previously completed item IDs in `previousCompletedIdsRef` before comparing transitions.
- Add a component test in `frontend/src/__tests__/DownloadQueue.test.tsx` that simulates a `processing` -> `completed` transition and asserts `invalidateQueries({ queryKey: ['videos'] })` is invoked.

### Testing
- Ran `npm --prefix frontend run test -- DownloadQueue.test.tsx` which passed with "Test Files 14 passed (14); Tests 166 passed (166)" and was verified at `2026-03-28T05:47:28Z`.
- Ran `npm --prefix frontend run lint` which completed successfully with no lint errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c76aab5b4483328af0408f10c9e68d)