### PR TITLE
fix(youtube): two-pass download, replace FFmpeggy with execa, fix RATE_LIMITED error parsing

### DIFF
--- a/backend/src/__tests__/unit/services/thumbnailService.test.ts
+++ b/backend/src/__tests__/unit/services/thumbnailService.test.ts
@@ -1,6 +1,5 @@
 import { ThumbnailService } from '../../../services/thumbnailService';
 
-// Simple mocks
 const mockReaddir = jest.fn();
 const mockStat = jest.fn();
 const mockAccess = jest.fn();
@@ -12,23 +11,14 @@ jest.mock('fs/promises', () => ({
   stat: (...args: any[]) => mockStat(...args),
   access: (...args: any[]) => mockAccess(...args),
   mkdir: (...args: any[]) => mockMkdir(...args),
-  unlink: (...args: any[]) => mockUnlink(...args)
+  unlink: (...args: any[]) => mockUnlink(...args),
 }));
 
-const mockFFmpeggyRun = jest.fn();
-const mockFFmpeggyDone = jest.fn();
-const mockFFmpeggyOn = jest.fn();
-const mockFFmpeggyOff = jest.fn();
-const mockFFmpeggyRemoveListener = jest.fn();
-jest.mock('ffmpeggy', () => ({
-  FFmpeggy: jest.fn().mockImplementation(() => ({
-    run: mockFFmpeggyRun,
-    done: mockFFmpeggyDone,
-    on: mockFFmpeggyOn,
-    off: mockFFmpeggyOff,
-    removeListener: mockFFmpeggyRemoveListener
-  }))
-}));
+const mockExeca = jest.fn();
+jest.mock('execa', () => {
+  const fn = (...args: any[]) => mockExeca(...args);
+  return fn;
+});
 
 describe('ThumbnailService', () => {
   let service: ThumbnailService;
@@ -36,274 +26,162 @@ describe('ThumbnailService', () => {
   beforeEach(() => {
     service = new ThumbnailService('/test/temp', '/test/thumbnails');
     jest.clearAllMocks();
+    mockMkdir.mockResolvedValue(undefined);
   });
 
   describe('generateThumbnail', () => {
     it('should generate thumbnail successfully', async () => {
+      mockExeca.mockResolvedValue({ exitCode: 0 });
       mockAccess.mockResolvedValue(undefined);
-      mockMkdir.mockResolvedValue(undefined);
-      mockFFmpeggyRun.mockResolvedValue(undefined);
-      mockFFmpeggyDone.mockResolvedValue(undefined);
-      
+
       const result = await service.generateThumbnail('/test/video.mp4');
-      
+
       expect(result).toBe('/test/thumbnails/video.jpg');
+      expect(mockExeca).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.arrayContaining(['-i', '/test/video.mp4', '/test/thumbnails/video.jpg'])
+      );
+    });
+
+    it('should throw when ffmpeg fails', async () => {
+      mockExeca.mockRejectedValue(new Error('ffmpeg error'));
+
+      await expect(service.generateThumbnail('/test/video.mp4'))
+        .rejects.toThrow('Failed to generate thumbnail');
+    });
+
+    it('should throw when thumbnail file is not created after ffmpeg succeeds', async () => {
+      mockExeca.mockResolvedValue({ exitCode: 0 });
+      mockAccess.mockRejectedValue(new Error('not found'));
+
+      await expect(service.generateThumbnail('/test/video.mp4'))
+        .rejects.toThrow('Failed to generate thumbnail');
+    });
+  });
+
+  describe('generateThumbnailWithProgress', () => {
+    it('should call progress callback at 50% and 100% on success', async () => {
+      mockExeca.mockResolvedValue({ exitCode: 0 });
+      mockAccess.mockResolvedValue(undefined);
+
+      const progressCallback = jest.fn();
+      await service.generateThumbnailWithProgress('/test/video.mp4', progressCallback);
+
+      expect(progressCallback).toHaveBeenCalledWith(50);
+      expect(progressCallback).toHaveBeenCalledWith(100);
+      expect(progressCallback).toHaveBeenCalledTimes(2);
+    });
+
+    it('should work without progress callback', async () => {
+      mockExeca.mockResolvedValue({ exitCode: 0 });
+      mockAccess.mockResolvedValue(undefined);
+
+      await expect(service.generateThumbnailWithProgress('/test/video.mp4')).resolves.toBeDefined();
+    });
+
+    it('should propagate errors from generateThumbnail', async () => {
+      mockExeca.mockRejectedValue(new Error('ffmpeg failed'));
+
+      await expect(service.generateThumbnailWithProgress('/test/video.mp4'))
+        .rejects.toThrow('Failed to generate thumbnail');
     });
   });
 
   describe('thumbnailExists', () => {
     it('should return true when thumbnail exists', async () => {
       mockAccess.mockResolvedValue(undefined);
-      
-      const result = await service.thumbnailExists('/test/video.mp4');
-      
-      expect(result).toBe(true);
+      expect(await service.thumbnailExists('/test/video.mp4')).toBe(true);
     });
 
     it('should return false when thumbnail does not exist', async () => {
       mockAccess.mockRejectedValue(new Error('File not found'));
-      
-      const result = await service.thumbnailExists('/test/video.mp4');
-      
-      expect(result).toBe(false);
+      expect(await service.thumbnailExists('/test/video.mp4')).toBe(false);
     });
   });
 
   describe('getThumbnailPath', () => {
     it('should return correct thumbnail path', () => {
-      const result = service.getThumbnailPath('/test/video.mp4');
-      expect(result).toBe('/test/thumbnails/video.jpg');
+      expect(service.getThumbnailPath('/test/video.mp4')).toBe('/test/thumbnails/video.jpg');
     });
   });
 
   describe('cleanupTempFiles', () => {
     it('should clean up old temp files', async () => {
       const oldDate = new Date(Date.now() - 25 * 60 * 60 * 1000);
-      
+
       mockReaddir.mockResolvedValue(['old-file.jpg', 'new-file.jpg']);
-      mockStat.mockImplementation((filePath) => {
-        const isOld = String(filePath).includes('old-file');
-        return Promise.resolve({
-          mtime: isOld ? oldDate : new Date()
-        });
+      mockStat.mockImplementation((filePath: string) => {
+        const isOld = filePath.includes('old-file');
+        return Promise.resolve({ mtime: isOld ? oldDate : new Date() });
       });
       mockUnlink.mockResolvedValue(undefined);
-      
+
       const result = await service.cleanupTempFiles(24);
-      
       expect(result).toBe(1);
     });
 
     it('should handle cleanup errors gracefully', async () => {
       mockReaddir.mockRejectedValue(new Error('Directory access failed'));
-      
-      // Should not throw and return 0
-      const result = await service.cleanupTempFiles(24);
-      expect(result).toBe(0);
-    });
-  });
-
-  describe('generateThumbnail', () => {
-    it('should handle thumbnail generation failure', async () => {
-      // Mock ensureDirectoriesExist to work
-      mockAccess.mockResolvedValueOnce(undefined).mockResolvedValueOnce(undefined);
-      mockMkdir.mockResolvedValue(undefined);
-      mockFFmpeggyRun.mockResolvedValue(undefined);
-      mockFFmpeggyDone.mockResolvedValue(undefined);
-      // Mock final access check to fail (thumbnail verification)
-      mockAccess.mockRejectedValueOnce(new Error('Thumbnail not found'));
-      
-      await expect(service.generateThumbnail('/test/video.mp4'))
-        .rejects.toThrow('Thumbnail file was not created');
+      expect(await service.cleanupTempFiles(24)).toBe(0);
     });
   });
 });
 
 // Real FFmpeg Integration Tests (no mocks)
 describe('ThumbnailService - Real FFmpeg Integration', () => {
-  // Import the real service without mocks for these tests
   const { ThumbnailService: RealThumbnailService } = jest.requireActual('../../../services/thumbnailService');
   let realService: any;
   const tempDir = '/tmp/test-thumbnails';
   const thumbnailsDir = '/tmp/test-thumbnails/output';
-  
+
   beforeAll(async () => {
-    // Create test service instance with real implementation
     realService = new RealThumbnailService(tempDir, thumbnailsDir);
-    
-    // Clean up any previous test files
     try {
       const fs = await import('fs/promises');
       await fs.rm(tempDir, { recursive: true, force: true });
-    } catch (error) {
-      // Ignore cleanup errors
-    }
-  });
-  
-  afterAll(async () => {
-    // Clean up test files
-    try {
-      const fs = await import('fs/promises');
-      await fs.rm(tempDir, { recursive: true, force: true });
-    } catch (error) {
-      // Ignore cleanup errors
+    } catch {
+      // ignore
     }
   });
 
-  it('should handle FFmpeg binary not found gracefully', async () => {
-    // Test behavior when FFmpeg is not available by using nonexistent path
+  afterAll(async () => {
+    try {
+      const fs = await import('fs/promises');
+      await fs.rm(tempDir, { recursive: true, force: true });
+    } catch {
+      // ignore
+    }
+  });
+
+  it('should handle non-existent video file gracefully', async () => {
     await expect(
       realService.generateThumbnail('/nonexistent/video.mp4')
     ).rejects.toThrow();
-    // The exact error message might vary depending on FFmpeggy version and static binaries
   });
-  
-  // Note: Testing with actual video file would require a test video file
-  // This test would be enabled when test assets are available
+
   it.skip('should generate thumbnail from real video file with actual FFmpeg', async () => {
     const fs = await import('fs/promises');
-    
-    // Use temporary test file instead of deleted demo video
     const testVideoPath = `/tmp/test-video-${Date.now()}.mp4`;
-    
     try {
       const thumbnailPath = await realService.generateThumbnail(testVideoPath);
-      
       expect(thumbnailPath).toBeDefined();
-      await fs.access(thumbnailPath); // Should not throw if file exists
+      await fs.access(thumbnailPath);
     } catch (error) {
-      // Expected if test video doesn't exist
       expect(error).toBeDefined();
     }
   });
 });
 
-describe('ThumbnailService - generateThumbnailWithProgress', () => {
-  let service: ThumbnailService;
-
-  beforeEach(() => {
-    service = new ThumbnailService('/test', '/test');
-    jest.clearAllMocks();
-    
-    // Reset fs mocks
-    mockAccess.mockResolvedValue(undefined);
-    mockMkdir.mockResolvedValue(undefined);
-    
-    // Reset FFmpeggy mocks
-    mockFFmpeggyRun.mockResolvedValue(undefined);
-    mockFFmpeggyDone.mockResolvedValue(undefined);
-    mockFFmpeggyOn.mockReturnValue(undefined);
-    mockFFmpeggyRemoveListener.mockReturnValue(undefined);
-  });
-
-  it('should generate thumbnail with progress callback and clean up event listeners', async () => {
-    // Mock progress callback
-    const progressCallback = jest.fn();
-
-    // Execute the method
-    await service.generateThumbnailWithProgress('/test/video.mp4', progressCallback);
-
-    // Verify event listeners were set up
-    expect(mockFFmpeggyOn).toHaveBeenCalledWith('progress', expect.any(Function));
-    expect(mockFFmpeggyOn).toHaveBeenCalledWith('error', expect.any(Function));
-    
-    // Verify event listeners were cleaned up
-    expect(mockFFmpeggyRemoveListener).toHaveBeenCalledWith('progress', expect.any(Function));
-    expect(mockFFmpeggyRemoveListener).toHaveBeenCalledWith('error', expect.any(Function));
-  });
-
-  it('should generate thumbnail without progress callback and still clean up error listener', async () => {
-    await service.generateThumbnailWithProgress('/test/video.mp4');
-    
-    // Verify only error listener was set up (no progress listener)
-    expect(mockFFmpeggyOn).not.toHaveBeenCalledWith('progress', expect.any(Function));
-    expect(mockFFmpeggyOn).toHaveBeenCalledWith('error', expect.any(Function));
-    
-    // Verify error listener was cleaned up
-    expect(mockFFmpeggyRemoveListener).toHaveBeenCalledWith('error', expect.any(Function));
-    expect(mockFFmpeggyRemoveListener).toHaveBeenCalledTimes(1); // Only error handler
-  });
-
-  it('should clean up event listeners even when FFmpeg fails', async () => {
-    // Mock FFmpeggy to fail
-    mockFFmpeggyRun.mockRejectedValue(new Error('FFmpeg failed'));
-    
-    const progressCallback = jest.fn();
-    
-    try {
-      await service.generateThumbnailWithProgress('/test/video.mp4', progressCallback);
-    } catch (error) {
-      // Expected to fail
-    }
-    
-    // Verify event listeners were still cleaned up despite the error
-    expect(mockFFmpeggyRemoveListener).toHaveBeenCalledWith('progress', expect.any(Function));
-    expect(mockFFmpeggyRemoveListener).toHaveBeenCalledWith('error', expect.any(Function));
-  });
-
-  it('should clean up event listeners even when thumbnail file verification fails', async () => {
-    // Mock file access to fail (thumbnail not created)
-    mockAccess.mockRejectedValue(new Error('File not found'));
-    
-    const progressCallback = jest.fn();
-    
-    try {
-      await service.generateThumbnailWithProgress('/test/video.mp4', progressCallback);
-    } catch (error) {
-      // Expected to fail
-    }
-    
-    // Verify event listeners were cleaned up despite verification failure
-    expect(mockFFmpeggyRemoveListener).toHaveBeenCalledWith('progress', expect.any(Function));
-    expect(mockFFmpeggyRemoveListener).toHaveBeenCalledWith('error', expect.any(Function));
-  });
-
-  it('should handle progress events correctly', async () => {
-    const progressCallback = jest.fn();
-    
-    // Track the progress handler for manual testing
-    let capturedProgressHandler: any;
-    mockFFmpeggyOn.mockImplementation((event: string, handler: any) => {
-      if (event === 'progress') {
-        capturedProgressHandler = handler;
-      }
-    });
-
-    await service.generateThumbnailWithProgress('/test/video.mp4', progressCallback);
-    
-    // Manually trigger the captured progress handler to test the logic
-    expect(capturedProgressHandler).toBeDefined();
-    
-    capturedProgressHandler({ percent: 25.7 }); // Should round to 26
-    capturedProgressHandler({ percent: 50.2 }); // Should round to 50  
-    capturedProgressHandler({ percent: 75.9 }); // Should round to 76
-    capturedProgressHandler({}); // Should be ignored (no percent)
-    
-    expect(progressCallback).toHaveBeenCalledWith(26);
-    expect(progressCallback).toHaveBeenCalledWith(50);
-    expect(progressCallback).toHaveBeenCalledWith(76);
-    expect(progressCallback).toHaveBeenCalledTimes(3);
-  });
-});
-
-// Configuration branch coverage tests
 describe('ThumbnailService Configuration', () => {
   it('should handle module import without throwing errors', () => {
-    // Simple test that the module can be imported
-    // This covers the module-level configuration code paths
     expect(() => {
-      const { ThumbnailService } = require('../../../services/thumbnailService');
-      new ThumbnailService('/test', '/test');
+      const { ThumbnailService: T } = require('../../../services/thumbnailService');
+      new T('/test', '/test');
     }).not.toThrow();
   });
-  
-  it('should handle static binary configuration', () => {
-    // Test that static binaries are configured correctly
+
+  it('should have ffmpeg-static available', () => {
     const ffmpegStatic = require('ffmpeg-static');
-    const ffprobeStatic = require('ffprobe-static');
-    
     expect(ffmpegStatic).toBeDefined();
-    expect(ffprobeStatic).toBeDefined();
-    expect(ffprobeStatic.path).toBeDefined();
   });
 });

--- a/backend/src/__tests__/unit/services/youTubeFileDownloader.test.ts
+++ b/backend/src/__tests__/unit/services/youTubeFileDownloader.test.ts
@@ -27,30 +27,48 @@ describe('YouTubeFileDownloader', () => {
         title: 'Test Video'
       };
 
-      const mockSubprocess = Promise.resolve();
-      (mockSubprocess as any).stdout = { on: jest.fn() };
-      mockExec.mockReturnValue(mockSubprocess);
-      
+      const mockSubprocess = () => {
+        const p = Promise.resolve() as any;
+        p.stdout = { on: jest.fn() };
+        p.stderr = { on: jest.fn() };
+        p.kill = jest.fn();
+        return p;
+      };
+      mockExec.mockImplementation(mockSubprocess);
+
       mockReaddir.mockResolvedValue(['Test_Video-test123.mp4', 'other-file.txt']);
 
       const result = await downloader.download('https://www.youtube.com/watch?v=test123', metadata);
 
       expect(result).toBe('/test/temp/Test_Video-test123.mp4');
-      expect(mockExec).toHaveBeenCalledWith(
+      expect(mockExec).toHaveBeenCalledTimes(2);
+
+      // Pass 1: video + subtitles, no extractAudio
+      expect(mockExec).toHaveBeenNthCalledWith(
+        1,
         'https://www.youtube.com/watch?v=test123',
         expect.objectContaining({
           output: expect.stringContaining('Test_Video-test123'),
           format: 'bestvideo+bestaudio',
           mergeOutputFormat: 'mp4',
-          extractAudio: true,
-          audioFormat: 'mp3',
           writeSub: true,
           writeAutoSub: true,
           subLang: 'sv.*,en.*,de.*',
           convertSubs: 'srt',
           noPlaylist: true,
           restrictFilenames: true,
-          noWarnings: true
+        })
+      );
+
+      // Pass 2: audio extraction only
+      expect(mockExec).toHaveBeenNthCalledWith(
+        2,
+        'https://www.youtube.com/watch?v=test123',
+        expect.objectContaining({
+          format: 'bestaudio',
+          extractAudio: true,
+          audioFormat: 'mp3',
+          noPlaylist: true,
         })
       );
     });
@@ -61,8 +79,11 @@ describe('YouTubeFileDownloader', () => {
         title: 'Test Video'
       };
 
-      const mockSubprocess = Promise.reject(new Error('Download failed'));
-      (mockSubprocess as any).stdout = { on: jest.fn() };
+      const mockSubprocess = Object.assign(Promise.reject(new Error('Download failed')), {
+        stdout: { on: jest.fn() },
+        stderr: { on: jest.fn() },
+        kill: jest.fn(),
+      });
       mockExec.mockReturnValue(mockSubprocess);
 
       // Should throw a user-friendly error (not the raw internal message)
@@ -78,8 +99,11 @@ describe('YouTubeFileDownloader', () => {
 
       const internalPath = '/home/app/node_modules/yt-dlp/yt_dlp/__main__.py';
       const mockError = new Error(`yt-dlp failed: ${internalPath} --no-warnings`);
-      const mockSubprocess = Promise.reject(mockError);
-      (mockSubprocess as any).stdout = { on: jest.fn() };
+      const mockSubprocess = Object.assign(Promise.reject(mockError), {
+        stdout: { on: jest.fn() },
+        stderr: { on: jest.fn() },
+        kill: jest.fn(),
+      });
       mockExec.mockReturnValue(mockSubprocess);
 
       try {
@@ -98,10 +122,13 @@ describe('YouTubeFileDownloader', () => {
         title: 'Test Video'
       };
 
-      const mockSubprocess = Promise.resolve();
-      (mockSubprocess as any).stdout = { on: jest.fn() };
-      mockExec.mockReturnValue(mockSubprocess);
-      
+      const mkSub = () => Object.assign(Promise.resolve(), {
+        stdout: { on: jest.fn() },
+        stderr: { on: jest.fn() },
+        kill: jest.fn(),
+      });
+      mockExec.mockImplementation(mkSub);
+
       mockReaddir.mockResolvedValue(['other-file.txt']); // No matching file
 
       await expect(downloader.download('https://www.youtube.com/watch?v=test123', metadata))
@@ -114,10 +141,13 @@ describe('YouTubeFileDownloader', () => {
         title: 'Test Video: "Special" Characters/And\\More!'
       };
 
-      const mockSubprocess = Promise.resolve();
-      (mockSubprocess as any).stdout = { on: jest.fn() };
-      mockExec.mockReturnValue(mockSubprocess);
-      
+      const mkSub = () => Object.assign(Promise.resolve(), {
+        stdout: { on: jest.fn() },
+        stderr: { on: jest.fn() },
+        kill: jest.fn(),
+      });
+      mockExec.mockImplementation(mkSub);
+
       // Based on the actual filename sanitization logic: removes <>"/:*?|\ chars, converts spaces to _
       mockReaddir.mockResolvedValue(['Test_Video_Special_CharactersAndMore!-test123.mp4']);
 
@@ -135,9 +165,11 @@ describe('YouTubeFileDownloader', () => {
   describe('cancelDownload', () => {
     it('should send SIGTERM to active subprocess and return true', async () => {
       const mockKill = jest.fn();
-      const subprocess = new Promise<void>(resolve => setTimeout(resolve, 1000)) as any;
-      subprocess.stdout = { on: jest.fn() };
-      subprocess.kill = mockKill;
+      const subprocess = Object.assign(new Promise<void>(resolve => setTimeout(resolve, 1000)), {
+        stdout: { on: jest.fn() },
+        stderr: { on: jest.fn() },
+        kill: mockKill,
+      });
       mockExec.mockReturnValue(subprocess);
       mockReaddir.mockResolvedValue(['Test_Video-test123.mp4']);
 
@@ -164,9 +196,11 @@ describe('YouTubeFileDownloader', () => {
 
     it('should return false when called twice for same downloadId', async () => {
       const mockKill = jest.fn();
-      const subprocess = new Promise<void>(resolve => setTimeout(resolve, 1000)) as any;
-      subprocess.stdout = { on: jest.fn() };
-      subprocess.kill = mockKill;
+      const subprocess = Object.assign(new Promise<void>(resolve => setTimeout(resolve, 1000)), {
+        stdout: { on: jest.fn() },
+        stderr: { on: jest.fn() },
+        kill: mockKill,
+      });
       mockExec.mockReturnValue(subprocess);
       mockReaddir.mockResolvedValue(['Test_Video-test123.mp4']);
 

--- a/backend/src/__tests__/unit/utils/ytDlpErrorParser.test.ts
+++ b/backend/src/__tests__/unit/utils/ytDlpErrorParser.test.ts
@@ -72,6 +72,21 @@ describe('parseYtDlpError', () => {
     });
   });
 
+  describe('RATE_LIMITED', () => {
+    it('should detect HTTP 429 errors', () => {
+      const result = parseYtDlpError(
+        "ERROR: Unable to download video subtitles for 'sv-en': HTTP Error 429: Too Many Requests"
+      );
+      expect(result.code).toBe('RATE_LIMITED');
+      expect(result.message).toContain('rate-limiting');
+    });
+
+    it('should detect "too many requests" errors', () => {
+      const result = parseYtDlpError('ERROR: too many requests from your IP');
+      expect(result.code).toBe('RATE_LIMITED');
+    });
+  });
+
   describe('NETWORK_ERROR', () => {
     it('should detect HTTP error responses', () => {
       const result = parseYtDlpError('ERROR: Unable to download webpage: HTTP Error 503');

--- a/backend/src/services/thumbnailService.ts
+++ b/backend/src/services/thumbnailService.ts
@@ -1,39 +1,17 @@
-import { FFmpeggy } from 'ffmpeggy';
+import execa from 'execa';
 import { getErrorMessage } from '../utils/error';
 import * as path from 'path';
 import * as fs from 'fs/promises';
-import { config } from '../config';
 import { logger } from '../utils/logger';
 import { AppError } from '../middleware/errorHandler';
 
-// Import static binaries for reliable FFmpeg/FFprobe paths
+// Import static binary for reliable FFmpeg path
 import ffmpegBin from 'ffmpeg-static';
-const ffprobeStatic = require('ffprobe-static');
 
-// Configure FFmpeg binary paths for FFmpeggy using DefaultConfig with static binaries
-try {
-  if (FFmpeggy.DefaultConfig) {
-      FFmpeggy.DefaultConfig = {
-        ...FFmpeggy.DefaultConfig,
-        ffmpegBin: ffmpegBin || config.ffmpegPath,
-        ffprobeBin: ffprobeStatic.path || config.ffprobePath,
-      };
-    logger.info('FFmpeggy DefaultConfig configured with static binaries', { 
-      ffmpegBin: ffmpegBin || 'system fallback', 
-      ffprobeBin: ffprobeStatic.path || 'system fallback' 
-    });
-  } else {
-    logger.warn('FFmpeggy.DefaultConfig is not available');
-  }
-} catch (error) {
-  // Fallback for older versions or test environments
-  logger.warn('Could not configure FFmpeggy DefaultConfig, using fallback method', {
-    error: getErrorMessage(error)
-  });
-}
+const FFMPEG_BIN = ffmpegBin || 'ffmpeg';
 
 /**
- * Thumbnail generation service using FFmpeggy
+ * Thumbnail generation service using ffmpeg directly via execa
  */
 export class ThumbnailService {
   private readonly tempDirectory: string;
@@ -49,146 +27,51 @@ export class ThumbnailService {
    */
   async generateThumbnail(videoPath: string): Promise<string> {
     try {
-      // Ensure directories exist
       await this.ensureDirectoriesExist();
 
-      // Generate unique thumbnail filename
       const videoBasename = path.basename(videoPath, path.extname(videoPath));
       const thumbnailFilename = `${videoBasename}.jpg`;
       const thumbnailPath = path.join(this.thumbnailsDirectory, thumbnailFilename);
 
-      logger.info('Generating thumbnail', {
-        videoPath,
+      logger.info('Generating thumbnail', { videoPath, thumbnailPath });
+
+      await execa(FFMPEG_BIN, [
+        '-y',
+        '-ss', '00:00:01.000',
+        '-i', videoPath,
+        '-vframes', '1',
+        '-q:v', '2',
+        '-vf', 'scale=320:240',
         thumbnailPath,
-        videoBasename
-      });
+      ]);
 
-      // Create FFmpeggy instance with thumbnail extraction options
-      const ffmpeggy = new FFmpeggy({
-        input: videoPath,
-        output: thumbnailPath,
-        outputOptions: [
-          '-ss', '00:00:01.000',        // Seek to 1 second
-          '-vframes', '1',              // Extract 1 frame
-          '-q:v', '2',                  // High quality
-          '-vf', 'scale=320:240'        // Resize to thumbnail
-        ],
-        overwriteExisting: true
-      });
-
-      // Run FFmpeg thumbnail generation
-      await ffmpeggy.run();
-      await ffmpeggy.done();
-
-      // Verify thumbnail was created
-      try {
-        await fs.access(thumbnailPath);
-        logger.info('Thumbnail generated successfully', { thumbnailPath });
-        return thumbnailPath;
-      } catch (error) {
-        throw new AppError('Thumbnail file was not created', 500);
-      }
+      await fs.access(thumbnailPath);
+      logger.info('Thumbnail generated successfully', { thumbnailPath });
+      return thumbnailPath;
 
     } catch (error) {
       const errorMessage = getErrorMessage(error);
-      logger.error('Thumbnail generation failed', {
-        videoPath,
-        error: errorMessage
-      });
-      
+      logger.error('Thumbnail generation failed', { videoPath, error: errorMessage });
+
       if (error instanceof AppError) {
         throw error;
       }
-      
       throw new AppError(`Failed to generate thumbnail: ${errorMessage}`, 500);
     }
   }
 
   /**
-   * Generate thumbnail with progress tracking
+   * Generate thumbnail with progress tracking (simplified — no progress for single-frame extraction)
    */
   async generateThumbnailWithProgress(
     videoPath: string,
     progressCallback?: (progress: number) => void
   ): Promise<string> {
-    try {
-      // Ensure directories exist
-      await this.ensureDirectoriesExist();
-
-      // Generate unique thumbnail filename
-      const videoBasename = path.basename(videoPath, path.extname(videoPath));
-      const thumbnailFilename = `${videoBasename}.jpg`;
-      const thumbnailPath = path.join(this.thumbnailsDirectory, thumbnailFilename);
-
-      logger.info('Generating thumbnail with progress tracking', {
-        videoPath,
-        thumbnailPath
-      });
-
-      // Create FFmpeggy instance with progress tracking
-      const ffmpeggy = new FFmpeggy({
-        input: videoPath,
-        output: thumbnailPath,
-        outputOptions: [
-          '-ss', '00:00:01.000',
-          '-vframes', '1',
-          '-q:v', '2',
-          '-vf', 'scale=320:240'
-        ],
-        overwriteExisting: true
-      });
-
-      // Set up progress tracking
-      let progressHandler: ((progress: any) => void) | undefined;
-      if (progressCallback) {
-        progressHandler = (progress) => {
-          if (progress.percent) {
-            progressCallback(Math.round(progress.percent));
-          }
-        };
-        ffmpeggy.on('progress', progressHandler);
-      }
-
-      // Set up error handling
-      const errorHandler = (error: Error) => {
-        logger.error('FFmpeg thumbnail error', { error: error.message });
-      };
-      ffmpeggy.on('error', errorHandler);
-
-      try {
-        // Run thumbnail generation
-        await ffmpeggy.run();
-        await ffmpeggy.done();
-      } finally {
-        // Clean up event listeners
-        if (progressHandler) {
-          ffmpeggy.removeListener('progress', progressHandler);
-        }
-        ffmpeggy.removeListener('error', errorHandler);
-      }
-
-      // Verify thumbnail was created
-      try {
-        await fs.access(thumbnailPath);
-        logger.info('Thumbnail with progress generated successfully', { thumbnailPath });
-        return thumbnailPath;
-      } catch (error) {
-        throw new AppError('Thumbnail file was not created', 500);
-      }
-
-    } catch (error) {
-      const errorMessage = getErrorMessage(error);
-      logger.error('Thumbnail generation with progress failed', {
-        videoPath,
-        error: errorMessage
-      });
-      
-      if (error instanceof AppError) {
-        throw error;
-      }
-      
-      throw new AppError(`Failed to generate thumbnail: ${errorMessage}`, 500);
-    }
+    // Single-frame extraction has no meaningful progress; report 50% then 100%
+    if (progressCallback) progressCallback(50);
+    const result = await this.generateThumbnail(videoPath);
+    if (progressCallback) progressCallback(100);
+    return result;
   }
 
   /**
@@ -198,7 +81,6 @@ export class ThumbnailService {
     try {
       const videoBasename = path.basename(videoPath, path.extname(videoPath));
       const thumbnailPath = path.join(this.thumbnailsDirectory, `${videoBasename}.jpg`);
-      
       await fs.access(thumbnailPath);
       return true;
     } catch {
@@ -218,19 +100,8 @@ export class ThumbnailService {
    * Ensure required directories exist
    */
   private async ensureDirectoriesExist(): Promise<void> {
-    try {
-      await fs.access(this.tempDirectory);
-    } catch {
-      await fs.mkdir(this.tempDirectory, { recursive: true });
-      logger.info('Created temp directory', { path: this.tempDirectory });
-    }
-
-    try {
-      await fs.access(this.thumbnailsDirectory);
-    } catch {
-      await fs.mkdir(this.thumbnailsDirectory, { recursive: true });
-      logger.info('Created thumbnails directory', { path: this.thumbnailsDirectory });
-    }
+    await fs.mkdir(this.tempDirectory, { recursive: true });
+    await fs.mkdir(this.thumbnailsDirectory, { recursive: true });
   }
 
   /**
@@ -246,30 +117,20 @@ export class ThumbnailService {
         try {
           const filePath = path.join(this.tempDirectory, filename);
           const stats = await fs.stat(filePath);
-          
           if (stats.mtime.getTime() < cutoffTime) {
             await fs.unlink(filePath);
             cleanedCount++;
             logger.debug('Cleaned up old temp file', { filePath });
           }
         } catch (error) {
-          logger.warn('Failed to clean up temp file', { 
-            filename, 
-            error: getErrorMessage(error)
-          });
+          logger.warn('Failed to clean up temp file', { filename, error: getErrorMessage(error) });
         }
       }
 
-      logger.info('Thumbnail temp cleanup completed', { 
-        cleanedCount, 
-        maxAgeHours 
-      });
-      
+      logger.info('Thumbnail temp cleanup completed', { cleanedCount, maxAgeHours });
       return cleanedCount;
     } catch (error) {
-      logger.error('Failed to cleanup thumbnail temp files', {
-        error: getErrorMessage(error)
-      });
+      logger.error('Failed to cleanup thumbnail temp files', { error: getErrorMessage(error) });
       return 0;
     }
   }

--- a/backend/src/services/youTubeDownloadService.ts
+++ b/backend/src/services/youTubeDownloadService.ts
@@ -1,3 +1,4 @@
+import * as path from 'path';
 import { v4 as uuidv4 } from 'uuid';
 import { logger } from '../utils/logger';
 import { getErrorMessage } from '../utils/error';
@@ -65,19 +66,27 @@ export class YouTubeDownloadService {
       });
 
       let thumbnailPath: string | undefined;
-      try {
-        thumbnailPath = await this.thumbnailService.generateThumbnail(tempVideoPath);
-        logger.info('Thumbnail generated successfully', { 
+      const isAudioOnly = path.extname(tempVideoPath).toLowerCase() === '.mp3';
+      if (isAudioOnly) {
+        logger.info('Skipping thumbnail generation for audio-only file', {
           downloadId,
-          thumbnailPath 
+          tempVideoPath
         });
-      } catch (error) {
-        logger.warn('Thumbnail generation failed, continuing without thumbnail', {
-          downloadId,
-          videoPath: tempVideoPath,
-          error: getErrorMessage(error)
-        });
-        thumbnailPath = undefined;
+      } else {
+        try {
+          thumbnailPath = await this.thumbnailService.generateThumbnail(tempVideoPath);
+          logger.info('Thumbnail generated successfully', { 
+            downloadId,
+            thumbnailPath 
+          });
+        } catch (error) {
+          logger.warn('Thumbnail generation failed, continuing without thumbnail', {
+            downloadId,
+            videoPath: tempVideoPath,
+            error: getErrorMessage(error)
+          });
+          thumbnailPath = undefined;
+        }
       }
 
       const finalVideoPath = await this.fileManager.moveToLibrary(tempVideoPath, metadata);

--- a/backend/src/services/youTubeFileDownloader.ts
+++ b/backend/src/services/youTubeFileDownloader.ts
@@ -29,12 +29,11 @@ export class YouTubeFileDownloader {
         downloadId
       });
 
-      const subprocess = youtubedl.exec(url, {
+      // Pass 1: download best video+audio merged as MP4, plus subtitles
+      const videoSubprocess = youtubedl.exec(url, {
         output: outputTemplate,
         format: 'bestvideo+bestaudio',
         mergeOutputFormat: 'mp4',
-        extractAudio: true,
-        audioFormat: 'mp3',
         writeSub: true,
         writeAutoSub: true,
         subLang: 'sv.*,en.*,de.*',
@@ -42,37 +41,62 @@ export class YouTubeFileDownloader {
         noPlaylist: true,
         restrictFilenames: true,
         noWarnings: true,
+        ignoreErrors: true,
         jsRuntimes: 'node'
       });
 
-      const tracker = { subprocess, aborted: false };
+      const tracker = { subprocess: videoSubprocess, aborted: false };
       if (downloadId) {
         this.activeSubprocesses.set(downloadId, tracker);
       }
 
-      subprocess.stderr?.on('data', (data) => {
+      videoSubprocess.stderr?.on('data', (data) => {
         stderrOutput += data.toString();
       });
 
-      subprocess.stdout?.on('data', (data) => {
+      videoSubprocess.stdout?.on('data', (data) => {
         const output = data.toString();
         if (output.includes('[download]')) {
-          logger.debug('Download progress', { 
-            videoId: metadata.id,
-            progress: output.trim()
-          });
+          logger.debug('Download progress', { videoId: metadata.id, progress: output.trim() });
         }
       });
 
-      await subprocess;
+      await videoSubprocess;
+
+      // Pass 2: extract audio as MP3 (best audio only, no video stream)
+      if (!tracker.aborted) {
+        logger.info('Extracting audio track', { url, videoId: metadata.id });
+        const audioSubprocess = youtubedl.exec(url, {
+          output: outputTemplate,
+          format: 'bestaudio',
+          extractAudio: true,
+          audioFormat: 'mp3',
+          noPlaylist: true,
+          restrictFilenames: true,
+          noWarnings: true,
+          ignoreErrors: true,
+          jsRuntimes: 'node'
+        });
+
+        if (downloadId) {
+          tracker.subprocess = audioSubprocess;
+        }
+
+        audioSubprocess.stderr?.on('data', (data) => {
+          stderrOutput += data.toString();
+        });
+
+        await audioSubprocess;
+      }
 
       if (downloadId) {
         this.activeSubprocesses.delete(downloadId);
       }
 
       const tempFiles = await fs.readdir(this.tempDirectory);
-      const downloadedFile = tempFiles.find(file => 
-        file.startsWith(`${safeTitle}-${metadata.id}`) && path.extname(file).toLowerCase() === '.mp4'
+      const prefix = `${safeTitle}-${metadata.id}`;
+      const downloadedFile = tempFiles.find(
+        file => file.startsWith(prefix) && path.extname(file).toLowerCase() === '.mp4'
       );
 
       if (!downloadedFile) {

--- a/backend/src/utils/ytDlpErrorParser.ts
+++ b/backend/src/utils/ytDlpErrorParser.ts
@@ -39,6 +39,15 @@ export function parseYtDlpError(stderr: string): YtDlpErrorInfo {
     };
   }
 
+  // Rate limited
+  if (lowerStderr.includes('http error 429') || lowerStderr.includes('too many requests')) {
+    return {
+      code: 'RATE_LIMITED',
+      message: 'The video service is temporarily rate-limiting requests.',
+      suggestion: 'Please wait a moment and try again.',
+    };
+  }
+
   // Network error
   if (
     lowerStderr.includes('http error 503') ||


### PR DESCRIPTION
## Problem

Three separate bugs caused YouTube downloads to fail or crash the server:

1. **No MP4 produced** — `extractAudio: true` and `mergeOutputFormat: 'mp4'` were set in the same yt-dlp pass. These options are mutually exclusive: `--extract-audio` discards the video stream, so the pass always produced only an MP3 and never an MP4.

2. **Server crash after download** — After the broken single-pass yielded only an MP3, `ThumbnailService.generateThumbnail()` was called on the `.mp3` file. `FFmpeggy.awaitStatus()` is called without `await` internally, so when ffmpeg exited with code 234 ("no video stream"), the rejected promise was **unhandled** and crashed Node.js. The surrounding `try/catch` did not protect against this.

3. **HTTP 429 misclassified as VIDEO_UNAVAILABLE** — yt-dlp exits with code 1 when subtitle downloads are rate-limited (HTTP 429). The error parser matched a generic `http error` catch-all and returned `VIDEO_UNAVAILABLE` instead of `RATE_LIMITED`.

Note: thumbnails being left in `data/temp/thumbnails/` instead of `data/videos/` is tracked separately in issue #244.

## Solution

- **Two-pass yt-dlp**: Pass 1 downloads `bestvideo+bestaudio` → MP4 + SRT subtitles (no `extractAudio`). Pass 2 downloads `bestaudio` → MP3 with `extractAudio: true`. Both use the same output template, so `videoFileManager.moveToLibrary()` picks up all files via its prefix scan.
- **Replace FFmpeggy with direct `execa` call** — eliminates the unhandled-rejection crash vector entirely. The `generateThumbnailWithProgress` wrapper simplifies to fixed 50%/100% progress reports since single-frame extraction has no meaningful intermediate progress.
- **Audio-only guard** in `youTubeDownloadService` — if the primary file has a `.mp3` extension, skip `generateThumbnail` (belt-and-suspenders; after the fix the primary file is always MP4).
- **`RATE_LIMITED` case added before generic `http error` catch-all** in `ytDlpErrorParser`.
- **`ignoreErrors: true`** added to both yt-dlp passes so subtitle 429s don't abort the entire download.

## Changes

| File | Change |
|------|--------|
| `backend/src/services/youTubeFileDownloader.ts` | Split single pass into two sequential passes; add `ignoreErrors`; clean up subprocess mock shape in tests |
| `backend/src/services/thumbnailService.ts` | Replace FFmpeggy with direct `execa` call; simplify `generateThumbnailWithProgress` |
| `backend/src/services/youTubeDownloadService.ts` | Add `import * as path`; add audio-only guard for thumbnail |
| `backend/src/utils/ytDlpErrorParser.ts` | Add `RATE_LIMITED` before generic http-error catch-all |
| `backend/src/__tests__/unit/services/thumbnailService.test.ts` | Rewrite to mock `execa` instead of `FFmpeggy` |
| `backend/src/__tests__/unit/services/youTubeFileDownloader.test.ts` | Update for two-pass calls; fix subprocess mock shape |
| `backend/src/__tests__/unit/utils/ytDlpErrorParser.test.ts` | Add two tests for `RATE_LIMITED` |

## Testing

E2E verified at **2026-03-28T22:17Z** with `https://www.youtube.com/watch?v=E55uSCO5D2w`:

```
data/videos/The_Most_Insane_Weapon_You_Never_Heard_About-E55uSCO5D2w.mp4   648 MB ✅
data/videos/The_Most_Insane_Weapon_You_Never_Heard_About-E55uSCO5D2w.mp3    12 MB ✅
data/videos/The_Most_Insane_Weapon_You_Never_Heard_About-E55uSCO5D2w.en.srt       ✅
data/videos/The_Most_Insane_Weapon_You_Never_Heard_About-E55uSCO5D2w.en-en.srt    ✅
data/videos/The_Most_Insane_Weapon_You_Never_Heard_About-E55uSCO5D2w.en-orig.srt  ✅
data/temp/thumbnails/...E55uSCO5D2w.jpg  21 KB — served via GET /api/thumbnails/  HTTP 200 ✅
Queue status: completed. Server did NOT crash. ✅
263 backend + 166 frontend tests — all passing, 0 failing ✅
```

## Notes

- `data/temp/thumbnails/` placement is a pre-existing issue unrelated to this fix, tracked in #244.