### PR TITLE
Fix: parse yt-dlp stdout to propagate real download progress (#248)

### DIFF
--- a/backend/src/__tests__/unit/services/queueScheduler.test.ts
+++ b/backend/src/__tests__/unit/services/queueScheduler.test.ts
@@ -114,4 +114,100 @@ describe('processQueueItem', () => {
       expect(item.error).toBe('Download failed');
     });
   });
+
+  describe('progress reporting', () => {
+    it('should start metadata step at 5% instead of old 25%', async () => {
+      const item = makeQueueItem();
+      const progressSnapshots: number[] = [];
+
+      mockDownloadVideo.mockImplementation(async (_req: unknown, _key: unknown, _cb: unknown) => {
+        // Capture progress values written during the metadata step (before download)
+        progressSnapshots.push(item.progress);
+        return { status: 'success', videoPath: '/tmp/test.mp4' };
+      });
+
+      await processQueueItem(item, mockYoutubeService, mockSaveQueue);
+
+      expect(progressSnapshots[0]).toBe(5);
+    });
+
+    it('should map video phase percentage into the 25–75% range', async () => {
+      const item = makeQueueItem();
+      let capturedCallback: ((phase: 'video' | 'audio', percent: number) => void) | undefined;
+
+      mockDownloadVideo.mockImplementation(async (_req: unknown, _key: unknown, cb: (phase: 'video' | 'audio', percent: number) => void) => {
+        capturedCallback = cb;
+        return { status: 'success', videoPath: '/tmp/test.mp4' };
+      });
+
+      await processQueueItem(item, mockYoutubeService, mockSaveQueue);
+
+      // Simulate a video progress callback with 50% yt-dlp progress
+      capturedCallback?.('video', 50);
+      // 25 + 50 * 0.5 = 50
+      expect(item.progress).toBe(50);
+      expect(item.currentStep).toContain('Downloading video');
+    });
+
+    it('should map audio phase percentage into the 75–85% range', async () => {
+      const item = makeQueueItem();
+      let capturedCallback: ((phase: 'video' | 'audio', percent: number) => void) | undefined;
+
+      mockDownloadVideo.mockImplementation(async (_req: unknown, _key: unknown, cb: (phase: 'video' | 'audio', percent: number) => void) => {
+        capturedCallback = cb;
+        return { status: 'success', videoPath: '/tmp/test.mp4' };
+      });
+
+      await processQueueItem(item, mockYoutubeService, mockSaveQueue);
+
+      // Simulate audio at 50% → 75 + 50 * 0.1 = 80
+      capturedCallback?.('audio', 50);
+      expect(item.progress).toBe(80);
+      expect(item.currentStep).toContain('Downloading audio');
+    });
+
+    it('should throttle saves: only persist when progress advances by ≥2%', async () => {
+      const item = makeQueueItem();
+      let capturedCallback: ((phase: 'video' | 'audio', percent: number) => void) | undefined;
+
+      mockDownloadVideo.mockImplementation(async (_req: unknown, _key: unknown, cb: (phase: 'video' | 'audio', percent: number) => void) => {
+        capturedCallback = cb;
+        return { status: 'success', videoPath: '/tmp/test.mp4' };
+      });
+
+      mockSaveQueue.mockClear();
+      await processQueueItem(item, mockYoutubeService, mockSaveQueue);
+      mockSaveQueue.mockClear();
+
+      // Fire rapid updates: 0%, 1%, 2%, 3% yt-dlp → mapped 25, 25.5, 26, 26.5
+      capturedCallback?.('video', 0);   // 25.0 → Δ=20 ≥ 2 → saved (initial was 5)
+      const saveCountAfterFirst = mockSaveQueue.mock.calls.length;
+      capturedCallback?.('video', 0.5); // 25.25 → Δ < 2 → skipped
+      capturedCallback?.('video', 1);   // 25.5 → Δ < 2 → skipped
+      capturedCallback?.('video', 3);   // 26.5 → Δ < 2 from last save at 25 → skipped
+      capturedCallback?.('video', 4);   // 27 → Δ = 2 → saved
+      const saveCountAfterThrottle = mockSaveQueue.mock.calls.length;
+
+      expect(saveCountAfterFirst).toBe(1);    // only the ≥2% jump saved
+      expect(saveCountAfterThrottle).toBe(2); // one more save at the 2% boundary
+    });
+
+    it('should include progress percentage in currentStep message', async () => {
+      const item = makeQueueItem();
+      let capturedCallback: ((phase: 'video' | 'audio', percent: number) => void) | undefined;
+
+      mockDownloadVideo.mockImplementation(async (_req: unknown, _key: unknown, cb: (phase: 'video' | 'audio', percent: number) => void) => {
+        capturedCallback = cb;
+        return { status: 'success', videoPath: '/tmp/test.mp4' };
+      });
+
+      await processQueueItem(item, mockYoutubeService, mockSaveQueue);
+
+      capturedCallback?.('video', 40); // 25 + 40*0.5 = 45
+      expect(item.currentStep).toBe('Downloading video (45%)');
+
+      capturedCallback?.('audio', 100); // 75 + 100*0.1 = 85
+      expect(item.currentStep).toBe('Downloading audio (85%)');
+    });
+  });
 });

--- a/backend/src/__tests__/unit/services/youTubeFileDownloader.test.ts
+++ b/backend/src/__tests__/unit/services/youTubeFileDownloader.test.ts
@@ -176,6 +176,127 @@ describe('YouTubeFileDownloader', () => {
     });
   });
 
+  describe('progressCallback', () => {
+    it('should invoke callback with video phase and parsed percentage from yt-dlp stdout', async () => {
+      const metadata = { id: 'test123', title: 'Test Video' };
+      const received: Array<{ phase: string; percent: number }> = [];
+
+      let videoStdoutHandler: ((data: Buffer) => void) | undefined;
+      const mkSub = () => {
+        const p = Promise.resolve() as any;
+        p.stdout = {
+          on: jest.fn((event, handler) => {
+            if (event === 'data') videoStdoutHandler = handler;
+          })
+        };
+        p.stderr = { on: jest.fn() };
+        p.kill = jest.fn();
+        return p;
+      };
+      mockExec.mockImplementation(mkSub);
+      mockReaddir.mockResolvedValue(['Test_Video-test123.mp4']);
+
+      const downloadPromise = downloader.download(
+        'https://www.youtube.com/watch?v=test123',
+        metadata,
+        undefined,
+        (phase, percent) => received.push({ phase, percent })
+      );
+
+      // Simulate yt-dlp stdout lines for the video subprocess
+      videoStdoutHandler?.(Buffer.from('[download]  45.2% of 123.45MiB at 3.20MiB/s ETA 00:30\n'));
+      videoStdoutHandler?.(Buffer.from('[download] 100.0% of 123.45MiB\n'));
+
+      await downloadPromise;
+
+      expect(received).toContainEqual({ phase: 'video', percent: 45.2 });
+      expect(received).toContainEqual({ phase: 'video', percent: 100 });
+    });
+
+    it('should invoke callback with audio phase from audio subprocess stdout', async () => {
+      const metadata = { id: 'test123', title: 'Test Video' };
+      const received: Array<{ phase: string; percent: number }> = [];
+
+      const stdoutHandlers: Array<(data: Buffer) => void> = [];
+      const mkSub = () => {
+        const p = Promise.resolve() as any;
+        p.stdout = {
+          on: jest.fn((event, handler) => {
+            if (event === 'data') stdoutHandlers.push(handler);
+          })
+        };
+        p.stderr = { on: jest.fn() };
+        p.kill = jest.fn();
+        return p;
+      };
+      mockExec.mockImplementation(mkSub);
+      mockReaddir.mockResolvedValue(['Test_Video-test123.mp4']);
+
+      const downloadPromise = downloader.download(
+        'https://www.youtube.com/watch?v=test123',
+        metadata,
+        undefined,
+        (phase, percent) => received.push({ phase, percent })
+      );
+
+      await downloadPromise;
+
+      // Trigger audio stdout handler (second subprocess → second registered handler)
+      stdoutHandlers[1]?.(Buffer.from('[download]  60.0% of 5.23MiB\n'));
+
+      expect(received).toContainEqual({ phase: 'audio', percent: 60 });
+    });
+
+    it('should not throw when progressCallback is undefined (backward compatibility)', async () => {
+      const metadata = { id: 'test123', title: 'Test Video' };
+      const mkSub = () => Object.assign(Promise.resolve(), {
+        stdout: { on: jest.fn() },
+        stderr: { on: jest.fn() },
+        kill: jest.fn(),
+      });
+      mockExec.mockImplementation(mkSub);
+      mockReaddir.mockResolvedValue(['Test_Video-test123.mp4']);
+
+      await expect(
+        downloader.download('https://www.youtube.com/watch?v=test123', metadata)
+      ).resolves.toBe('/test/temp/Test_Video-test123.mp4');
+    });
+
+    it('should not fire callback for stdout lines without [download] percentage', async () => {
+      const metadata = { id: 'test123', title: 'Test Video' };
+      const received: Array<{ phase: string; percent: number }> = [];
+
+      let videoStdoutHandler: ((data: Buffer) => void) | undefined;
+      const mkSub = () => {
+        const p = Promise.resolve() as any;
+        p.stdout = {
+          on: jest.fn((event, handler) => {
+            if (event === 'data') videoStdoutHandler = handler;
+          })
+        };
+        p.stderr = { on: jest.fn() };
+        p.kill = jest.fn();
+        return p;
+      };
+      mockExec.mockImplementation(mkSub);
+      mockReaddir.mockResolvedValue(['Test_Video-test123.mp4']);
+
+      const downloadPromise = downloader.download(
+        'https://www.youtube.com/watch?v=test123',
+        metadata,
+        undefined,
+        (phase, percent) => received.push({ phase, percent })
+      );
+
+      videoStdoutHandler?.(Buffer.from('[download] Destination: /tmp/file.mp4\n'));
+      videoStdoutHandler?.(Buffer.from('[info] Writing subtitles\n'));
+
+      await downloadPromise;
+
+      expect(received).toHaveLength(0);
+    });
+  });
+
   describe('cancelDownload', () => {
     it('should send SIGTERM to active subprocess and return true', async () => {
       const mockKill = jest.fn();

--- a/backend/src/services/queueScheduler.ts
+++ b/backend/src/services/queueScheduler.ts
@@ -73,7 +73,7 @@ export async function processQueueItem(
       return;
     }
 
-    item.progress = 25;
+    item.progress = 5;
     item.currentStep = 'Fetching video metadata';
     await saveQueue();
 
@@ -85,7 +85,24 @@ export async function processQueueItem(
       return;
     }
 
-    const result = await youtubeDownloadService.downloadVideo(item.request, item.id);
+    // Phase-weighted progress: video 25–75%, audio 75–85%
+    // Throttle: only persist to JSON when progress changes by ≥2%
+    let lastSavedProgress = 5;
+    const updateProgress = (phase: 'video' | 'audio', percent: number): void => {
+      const mapped = phase === 'video'
+        ? 25 + percent * 0.5   // 0–100 → 25–75
+        : 75 + percent * 0.1;  // 0–100 → 75–85
+      if (mapped - lastSavedProgress >= 2) {
+        item.progress = Math.round(mapped);
+        item.currentStep = phase === 'video'
+          ? `Downloading video (${item.progress}%)`
+          : `Downloading audio (${item.progress}%)`;
+        lastSavedProgress = mapped;
+        saveQueue();
+      }
+    };
+
+    const result = await youtubeDownloadService.downloadVideo(item.request, item.id, updateProgress);
 
     if ((item as QueueItem).status === 'cancelled') {
       logger.info('Queue item cancelled during download, cleaning up', {

--- a/backend/src/services/youTubeDownloadService.ts
+++ b/backend/src/services/youTubeDownloadService.ts
@@ -8,7 +8,7 @@ import { VideoInfoFile } from '../types/video';
 import { ThumbnailService } from './thumbnailService';
 import { YouTubeUrlValidator } from './youTubeUrlValidator';
 import { YouTubeMetadataExtractor } from './youTubeMetadataExtractor';
-import { YouTubeFileDownloader } from './youTubeFileDownloader';
+import { YouTubeFileDownloader, DownloadProgressCallback } from './youTubeFileDownloader';
 import { VideoFileManager } from './videoFileManager';
 
 /**
@@ -33,7 +33,7 @@ export class YouTubeDownloadService {
     this.thumbnailService = thumbnailService;
   }
 
-  async downloadVideo(request: DownloadRequest, cancelKey?: string): Promise<DownloadResult> {
+  async downloadVideo(request: DownloadRequest, cancelKey?: string, progressCallback?: DownloadProgressCallback): Promise<DownloadResult> {
     const startedAt = new Date();
     const downloadId = uuidv4();
     // Use cancelKey as the subprocess identifier when provided so callers
@@ -61,7 +61,7 @@ export class YouTubeDownloadService {
         duration: metadata.duration
       });
 
-      const tempVideoPath = await this.fileDownloader.download(request.url, metadata, subprocessKey);
+      const tempVideoPath = await this.fileDownloader.download(request.url, metadata, subprocessKey, progressCallback);
       logger.info('Video downloaded to temp location', {
         downloadId,
         tempPath: tempVideoPath

--- a/backend/src/services/youTubeFileDownloader.ts
+++ b/backend/src/services/youTubeFileDownloader.ts
@@ -7,6 +7,8 @@ import { AppError } from '../middleware/errorHandler';
 import { YouTubeMetadata } from '../types/youtube';
 import { parseYtDlpError } from '../utils/ytDlpErrorParser';
 
+export type DownloadProgressCallback = (phase: 'video' | 'audio', percent: number) => void;
+
 export class YouTubeFileDownloader {
   private readonly tempDirectory: string;
   private activeSubprocesses: Map<string, { subprocess: ReturnType<typeof youtubedl.exec>, aborted: boolean }> = new Map();
@@ -15,7 +17,12 @@ export class YouTubeFileDownloader {
     this.tempDirectory = tempDirectory;
   }
 
-  async download(url: string, metadata: YouTubeMetadata, downloadId?: string): Promise<string> {
+  async download(
+    url: string,
+    metadata: YouTubeMetadata,
+    downloadId?: string,
+    progressCallback?: DownloadProgressCallback
+  ): Promise<string> {
     let stderrOutput = '';
 
     try {
@@ -57,6 +64,10 @@ export class YouTubeFileDownloader {
       videoSubprocess.stdout?.on('data', (data) => {
         const output = data.toString();
         if (output.includes('[download]')) {
+          const percentMatch = output.match(/\[download\]\s+([\d.]+)%/);
+          if (percentMatch && progressCallback) {
+            progressCallback('video', parseFloat(percentMatch[1]));
+          }
           logger.debug('Download progress', { videoId: metadata.id, progress: output.trim() });
         }
       });
@@ -84,6 +95,16 @@ export class YouTubeFileDownloader {
 
         audioSubprocess.stderr?.on('data', (data) => {
           stderrOutput += data.toString();
+        });
+
+        audioSubprocess.stdout?.on('data', (data) => {
+          const output = data.toString();
+          if (output.includes('[download]')) {
+            const percentMatch = output.match(/\[download\]\s+([\d.]+)%/);
+            if (percentMatch && progressCallback) {
+              progressCallback('audio', parseFloat(percentMatch[1]));
+            }
+          }
         });
 
         await audioSubprocess;


### PR DESCRIPTION
## Summary

The download queue progress bar was permanently stuck at 25% for the entire duration of a video download. yt-dlp subprocess stdout already contained real percentages (e.g. `[download] 45.2% of 123.45MiB`) but was only logged at DEBUG level — never forwarded to the caller.

## Root Cause

`youTubeFileDownloader.ts:57-62` parsed `[download]` lines from yt-dlp stdout but fired no callback. The `downloadVideo()` call chain had no progress parameter at any layer, so `queueScheduler.ts` could only hardcode `progress = 25` then `progress = 100`.

## Changes

| File | Change |
|------|--------|
| `backend/src/services/youTubeFileDownloader.ts` | Add `DownloadProgressCallback` type and optional `progressCallback` param to `download()`; parse `[download] X%` from both video and audio subprocess stdout |
| `backend/src/services/youTubeDownloadService.ts` | Thread `progressCallback` through `downloadVideo()` to the file downloader |
| `backend/src/services/queueScheduler.ts` | Provide phase-weighted callback (video 25–75%, audio 75–85%); throttle queue saves to ≥2% progress change; update `currentStep` with phase + percentage; start metadata step at 5% (was 25%) |
| `backend/src/__tests__/unit/services/youTubeFileDownloader.test.ts` | Added 4 tests: parsing video/audio stdout, backward compat (no callback), non-percentage lines skipped |
| `backend/src/__tests__/unit/services/queueScheduler.test.ts` | Added 5 tests: 5% metadata start, video range mapping, audio range mapping, 2% throttle, currentStep messages |

## Testing

- [x] Type check passes (`npm run type-check`)
- [x] Unit tests pass — 280 backend + 166 frontend tests all green
- [x] Lint passes
- [x] Pre-push hook: lint + type-check + build all pass

## Validation

```bash
cd backend && npm run type-check && npm test -- --testPathPattern="youTubeFileDownloader|queueScheduler" && npm run lint
```

## Issue

Fixes #248

---

<details>
<summary>Implementation Details</summary>

### Implementation followed artifact:

Investigation comment on issue #248

### Phase weighting applied:

| Phase | Progress range |
|-------|---------------|
| Validation + directory setup | 0–5% |
| Metadata extraction | 5–25% |
| Video file download | 25–75% |
| Audio file download | 75–85% |
| (Thumbnail + move handled by existing 85–100 steps) |

### Deviations from plan:

- `thumbnailService.generateThumbnailWithProgress` was not wired in (it already exists as a stub but `youTubeDownloadService` calls `generateThumbnail` directly). The thumbnail step is implicitly covered by the 85–100% range completing at `progress = 100` after download. This is an acceptable minimal scope; the stub can be wired in a follow-up.

</details>

---

_Automated implementation from investigation artifact_