### PR TITLE
Adjust download queue progress bar bottom spacing

### DIFF
--- a/frontend/src/components/DownloadQueue.tsx
+++ b/frontend/src/components/DownloadQueue.tsx
@@ -121,7 +121,7 @@ function QueueItemComponent({ item, onCancel, className = '' }: QueueItemCompone
 
         {/* Progress bar for processing items */}
         {item.status === 'processing' && (
-          <div className="mt-3">
+          <div className="mt-3 pb-2">
             <div 
               className="w-full bg-gray-200 rounded-full h-2" 
               role="progressbar"


### PR DESCRIPTION
### Motivation
- Improve visual spacing between the processing progress bar and the card border so the load bar doesn't sit flush against the bottom edge.

### Description
- Change the processing-item wrapper in `frontend/src/components/DownloadQueue.tsx` from `className="mt-3"` to `className="mt-3 pb-2"` to add a small bottom padding for a cleaner layout.

### Testing
- Ran `make lint` (2026-03-30) which failed with ESLint v9 error "couldn't find eslint.config.(js|mjs|cjs)"; ran `make test` which failed with `jest: not found`; and ran `make install` which failed during the `prepare` script with `husky: not found`, so automated CI/test steps could not complete successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cab9268ac08332ac8dac3262380d36)