### PR TITLE
Fix: constrain yt-dlp to H.264 codec to prevent AV1 downloads (#268)

### DIFF
--- a/backend/src/__tests__/unit/services/youTubeFileDownloader.test.ts
+++ b/backend/src/__tests__/unit/services/youTubeFileDownloader.test.ts
@@ -69,7 +69,7 @@ describe('YouTubeFileDownloader', () => {
         'https://www.youtube.com/watch?v=test123',
         expect.objectContaining({
           output: expect.stringContaining('Test_Video-test123'),
-          format: 'bestvideo[ext=mp4]+bestaudio[ext=m4a]/bestvideo[ext=webm]+bestaudio[ext=webm]/best[ext=mp4]/best[ext=webm]',
+          format: 'bestvideo[ext=mp4][vcodec^=avc1]+bestaudio[ext=m4a]/bestvideo[ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best',
           mergeOutputFormat: 'mp4/webm',
           writeSub: true,
           writeAutoSub: true,

--- a/backend/src/services/youTubeFileDownloader.ts
+++ b/backend/src/services/youTubeFileDownloader.ts
@@ -39,7 +39,7 @@ export class YouTubeFileDownloader {
       // Pass 1: download best video+audio merged as MP4 (prefer) or WebM (fallback), plus subtitles
       const videoSubprocess = youtubedl.exec(url, {
         output: outputTemplate,
-        format: 'bestvideo[ext=mp4]+bestaudio[ext=m4a]/bestvideo[ext=webm]+bestaudio[ext=webm]/best[ext=mp4]/best[ext=webm]',
+        format: 'bestvideo[ext=mp4][vcodec^=avc1]+bestaudio[ext=m4a]/bestvideo[ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best',
         mergeOutputFormat: 'mp4/webm',
         writeThumbnail: true,
         writeSub: true,


### PR DESCRIPTION
## Summary

The yt-dlp format selector in `youTubeFileDownloader.ts` selected the \"best\" quality video stream without constraining codec. YouTube serves 1080p60+ streams encoded with AV1 (av01) inside MP4 containers, which fail to play in Safari < 17 and browsers/devices without AV1 hardware decode support.

## Root Cause

`bestvideo[ext=mp4]` selects highest quality video in an MP4 container but does not restrict codec. yt-dlp picks AV1 for popular high-resolution videos because it achieves higher quality at lower bitrate. The resulting `.mp4` files are valid containers but fail to play in any browser lacking AV1 support.

## Changes

| File | Change |
|------|--------|
| `backend/src/services/youTubeFileDownloader.ts` | Add `[vcodec^=avc1]` constraint to format selector; remove WebM fallback (AV1 also common in WebM) |
| `backend/src/__tests__/unit/services/youTubeFileDownloader.test.ts` | Update test expectation to match updated format string |

## Testing

- [x] Type check passes
- [x] Unit tests pass (14/14 in youTubeFileDownloader.test.ts, 287/292 total)
- [x] Lint passes
- [x] Pre-push validation passed (lint + type-check + build)

## Validation

```bash
cd backend && npm run type-check
cd backend && npm test -- --testPathPattern="youTubeFileDownloader"
cd backend && npm run lint
```

## Issue

Fixes #268

---

<details>
<summary>Implementation Details</summary>

### Implementation followed artifact:

`.ghar/issues/issue-268.md`

### Deviations from plan:

None - implemented exactly as specified in the investigation artifact.

</details>

---

_Automated implementation from investigation artifact_