### PR TITLE
chore: update stale WebM comment and mergeOutputFormat (#270)

### DIFF
--- a/backend/src/__tests__/unit/services/youTubeFileDownloader.test.ts
+++ b/backend/src/__tests__/unit/services/youTubeFileDownloader.test.ts
@@ -70,7 +70,7 @@ describe('YouTubeFileDownloader', () => {
         expect.objectContaining({
           output: expect.stringContaining('Test_Video-test123'),
           format: 'bestvideo[ext=mp4][vcodec^=avc1]+bestaudio[ext=m4a]/bestvideo[ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best',
-          mergeOutputFormat: 'mp4/webm',
+          mergeOutputFormat: 'mp4',
           writeSub: true,
           writeAutoSub: true,
           subLang: 'sv.*,en.*,de.*',

--- a/backend/src/services/youTubeFileDownloader.ts
+++ b/backend/src/services/youTubeFileDownloader.ts
@@ -36,11 +36,11 @@ export class YouTubeFileDownloader {
         downloadId
       });
 
-      // Pass 1: download best video+audio merged as MP4 (prefer) or WebM (fallback), plus subtitles
+      // Pass 1: download best H.264 video+audio merged as MP4, plus subtitles
       const videoSubprocess = youtubedl.exec(url, {
         output: outputTemplate,
         format: 'bestvideo[ext=mp4][vcodec^=avc1]+bestaudio[ext=m4a]/bestvideo[ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best',
-        mergeOutputFormat: 'mp4/webm',
+        mergeOutputFormat: 'mp4',
         writeThumbnail: true,
         writeSub: true,
         writeAutoSub: true,


### PR DESCRIPTION
## Summary

After PR #269 removed WebM fallback selectors to prevent AV1-encoded downloads that fail in Safari < 17, the comment at `youTubeFileDownloader.ts:39` and the `mergeOutputFormat` config were not updated to reflect the H.264-only intent.

## Root Cause

PR #269 intentionally removed WebM fallback to prevent AV1 codec issues but the documentation (comment) and merge output format configuration were not updated in sync, leaving misleading references to WebM.

## Changes

| File | Change |
|------|--------|
| `backend/src/services/youTubeFileDownloader.ts` | Update comment at line 39 to reflect H.264-first behavior; change `mergeOutputFormat` from `'mp4/webm'` to `'mp4'` |
| `backend/src/__tests__/unit/services/youTubeFileDownloader.test.ts` | Update assertion to match new `mergeOutputFormat: 'mp4'` value |

## Testing

- [x] Type check passes
- [x] Unit tests pass (292 tests, 5 skipped)
- [x] Lint passes
- [x] Comment at line 39 now reads "download best H.264 video+audio merged as MP4"
- [x] `mergeOutputFormat` is set to `'mp4'`

## Validation

```bash
cd backend && npm run type-check && npm run lint
```

## Issue

Fixes #270

---

<details>
<summary>Implementation Details</summary>

### Implementation followed artifact:

`.ghar/issues/issue-270.md` (investigation comment on issue #270)

### Deviations from plan:

- Unit test assertion for `mergeOutputFormat` also updated from `'mp4/webm'` to `'mp4'` (artifact's scope section marked test files as OUT OF SCOPE, but the existing test was directly asserting the old value and would have failed — fixing it is mandatory per boyscout rule)

</details>

---

_Automated implementation from investigation artifact_