### PR TITLE
Fix: inject ThumbnailService into VideoService for consistent auto-regeneration (#267)

### DIFF
--- a/backend/src/__tests__/unit/services/videoService.test.ts
+++ b/backend/src/__tests__/unit/services/videoService.test.ts
@@ -22,6 +22,7 @@ jest.mock('fs', () => ({
 }));
 
 import { VideoService } from '../../../services/videoService';
+import { ThumbnailService } from '../../../services/thumbnailService';
 import { promises as fs } from 'fs';
 
 // Get references to the mocked functions
@@ -717,6 +718,103 @@ describe('VideoService', () => {
       expect(result.width).toBeUndefined();
       expect(result.height).toBeUndefined();
       expect(result.format).toBe('MP4');
+    });
+  });
+
+  describe('scanVideoDirectory with ThumbnailService injection', () => {
+    let mockThumbnailService: jest.Mocked<Pick<ThumbnailService, 'generateThumbnail'>>;
+
+    beforeEach(() => {
+      mockThumbnailService = {
+        generateThumbnail: jest.fn()
+      };
+      jest.clearAllMocks();
+      const enoentError = Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+      mockFs.readFile.mockRejectedValue(enoentError);
+    });
+
+    it('should call generateThumbnail for videos without thumbnails when ThumbnailService is injected', async () => {
+      const serviceWithThumb = new VideoService(testVideosDir, mockThumbnailService as unknown as ThumbnailService);
+      mockThumbnailService.generateThumbnail.mockResolvedValue('/test/videos/video1.jpg');
+
+      mockFs.access.mockResolvedValue(undefined);
+      // readdir: first call lists video files, then two calls for findThumbnailsBatch and findThumbnail fallback
+      mockFs.readdir
+        .mockResolvedValueOnce(['video1.mp4'] as any)   // directory listing
+        .mockResolvedValueOnce([] as any)               // findThumbnailsBatch: no thumbnails found
+        .mockResolvedValueOnce(['video1.jpg'] as any);  // findThumbnail after regeneration
+      mockFs.stat.mockResolvedValue({
+        isDirectory: () => false,
+        isFile: () => true,
+        size: 1000000,
+        mtime: new Date('2024-01-01')
+      } as any);
+
+      await serviceWithThumb.scanVideoDirectory();
+
+      expect(mockThumbnailService.generateThumbnail).toHaveBeenCalledWith(
+        path.join(testVideosDir, 'video1.mp4')
+      );
+    });
+
+    it('should not call generateThumbnail when ThumbnailService is not injected', async () => {
+      const serviceWithoutThumb = new VideoService(testVideosDir);
+
+      mockFs.access.mockResolvedValue(undefined);
+      mockFs.readdir
+        .mockResolvedValueOnce(['video1.mp4'] as any)
+        .mockResolvedValueOnce([] as any);
+      mockFs.stat.mockResolvedValue({
+        isDirectory: () => false,
+        isFile: () => true,
+        size: 1000000,
+        mtime: new Date('2024-01-01')
+      } as any);
+
+      await serviceWithoutThumb.scanVideoDirectory();
+
+      expect(mockThumbnailService.generateThumbnail).not.toHaveBeenCalled();
+    });
+
+    it('should handle thumbnail generation errors gracefully and continue scan', async () => {
+      const serviceWithThumb = new VideoService(testVideosDir, mockThumbnailService as unknown as ThumbnailService);
+      mockThumbnailService.generateThumbnail.mockRejectedValue(new Error('Generation failed'));
+
+      mockFs.access.mockResolvedValue(undefined);
+      mockFs.readdir
+        .mockResolvedValueOnce(['video1.mp4'] as any)
+        .mockResolvedValueOnce([] as any);
+      mockFs.stat.mockResolvedValue({
+        isDirectory: () => false,
+        isFile: () => true,
+        size: 1000000,
+        mtime: new Date('2024-01-01')
+      } as any);
+
+      const result = await serviceWithThumb.scanVideoDirectory();
+
+      // Scan should complete despite thumbnail error
+      expect(result.videos).toHaveLength(1);
+      expect(result.errors).toContainEqual(expect.stringContaining('Failed to generate thumbnail for video1.mp4'));
+    });
+
+    it('should not call generateThumbnail when thumbnail already exists', async () => {
+      const serviceWithThumb = new VideoService(testVideosDir, mockThumbnailService as unknown as ThumbnailService);
+
+      mockFs.access.mockResolvedValue(undefined);
+      mockFs.readdir
+        .mockResolvedValueOnce(['video1.mp4'] as any)
+        .mockResolvedValueOnce(['video1.mp4', 'video1.jpg'] as any); // thumbnail already present
+      mockFs.stat.mockResolvedValue({
+        isDirectory: () => false,
+        isFile: () => true,
+        size: 1000000,
+        mtime: new Date('2024-01-01')
+      } as any);
+
+      await serviceWithThumb.scanVideoDirectory();
+
+      expect(mockThumbnailService.generateThumbnail).not.toHaveBeenCalled();
     });
   });
 });

--- a/backend/src/routes/api.ts
+++ b/backend/src/routes/api.ts
@@ -3,6 +3,7 @@ import fs from 'fs';
 import path from 'path';
 import { config } from '../config';
 import { VideoService } from '../services/videoService';
+import { thumbnailService } from '../services';
 import { catchAsync, AppError } from '../middleware/errorHandler';
 import { logger } from '../utils/logger';
 import { validateVideoFilename, validateImageFilename, validatePathInDirectory, validateDownloadableFilename } from '../utils/fileValidation';
@@ -10,9 +11,9 @@ import youtubeRouter from './youtube';
 
 const router = Router();
 
-// Initialize video service (in production this would come from DI container)
+// Initialize video service with ThumbnailService for auto-regeneration
 const videosDirectory = config.videosDir;
-const videoService = new VideoService(videosDirectory);
+const videoService = new VideoService(videosDirectory, thumbnailService);
 const MAX_THUMBNAIL_SIZE = config.thumbnailMaxSize;
 const THUMBNAIL_CACHE_DURATION = config.thumbnailCacheDuration;
 

--- a/backend/src/routes/health/probes.ts
+++ b/backend/src/routes/health/probes.ts
@@ -4,6 +4,7 @@ import os from 'os';
 import path from 'path';
 import { config } from '../../config';
 import { logger } from '../../utils/logger';
+import { thumbnailService } from '../../services';
 import { DirectoryDiskSpace, DirectoryHealth, VideoServiceHealth } from './types';
 
 const DISK_SPACE_WARNING_THRESHOLD = 0.9;
@@ -107,7 +108,7 @@ export async function getVideoServiceHealth(): Promise<VideoServiceHealth> {
 
   try {
     const { VideoService } = await import('../../services/videoService');
-    const videoService = new VideoService(getVideosDirectory());
+    const videoService = new VideoService(getVideosDirectory(), thumbnailService);
     const result = await videoService.scanVideoDirectory();
 
     health.lastScan = new Date().toISOString();

--- a/backend/src/services/videoService.ts
+++ b/backend/src/services/videoService.ts
@@ -3,6 +3,7 @@ import { getErrorMessage } from '../utils/error';
 import path from 'path';
 import { config } from '../config';
 import { logger } from '../utils/logger';
+import { ThumbnailService } from './thumbnailService';
 import { 
   VideoFile, 
   VideoMetadata, 
@@ -25,9 +26,13 @@ export class VideoService {
   private readonly AUDIO_EXTENSIONS = ['.mp3'];
   private readonly TRANSCRIPT_EXTENSION = '.srt';
   private readonly INFO_EXTENSION = '.info.json';
+  private readonly thumbnailService?: ThumbnailService;
 
-  constructor(videosDirectory: string) {
+  constructor(videosDirectory: string, thumbnailService?: ThumbnailService) {
     this.videosDirectory = videosDirectory;
+    if (thumbnailService) {
+      this.thumbnailService = thumbnailService;
+    }
   }
 
   /**
@@ -73,6 +78,26 @@ export class VideoService {
 
       // Second pass: resolve thumbnails in batches per directory
       const thumbnailMap = await this.findThumbnailsBatch(videoFiles);
+
+      // Auto-regenerate missing thumbnails if ThumbnailService is available
+      if (this.thumbnailService) {
+        for (const videoFile of videoFiles) {
+          if (!thumbnailMap.has(videoFile.path)) {
+            try {
+              await this.thumbnailService.generateThumbnail(videoFile.path);
+              // Re-scan to pick up the newly generated thumbnail
+              const newThumbnail = await this.findThumbnail(videoFile.path);
+              if (newThumbnail) {
+                thumbnailMap.set(videoFile.path, newThumbnail);
+              }
+            } catch (error) {
+              const errorMessage = getErrorMessage(error);
+              errors.push(`Failed to generate thumbnail for ${videoFile.name}: ${errorMessage}`);
+              logger.warn(`Thumbnail auto-regeneration failed for ${videoFile.name}`, { error: errorMessage });
+            }
+          }
+        }
+      }
 
       // Third pass: create videos with metadata
       for (const videoFile of videoFiles) {


### PR DESCRIPTION
## Summary

Health probe and production API both created `VideoService` without injecting `ThumbnailService`, so `scanVideoDirectory()` never triggered auto-regeneration of missing thumbnails in either code path.

## Root Cause

`VideoService` had no mechanism to accept a `ThumbnailService` dependency. Both call sites (`probes.ts` and `api.ts`) instantiated it with only the videos directory, leaving the auto-regeneration path permanently inactive.

## Changes

| File | Change |
|------|--------|
| `backend/src/services/videoService.ts` | Add optional `ThumbnailService` parameter to constructor; add auto-regeneration loop in `scanVideoDirectory()` |
| `backend/src/routes/health/probes.ts` | Import and inject `thumbnailService` singleton into `VideoService` |
| `backend/src/routes/api.ts` | Import and inject `thumbnailService` singleton into `VideoService` |
| `backend/src/__tests__/unit/services/videoService.test.ts` | Add 4 unit tests for injection behavior, error handling, and no-op when thumbnail already exists |

## Testing

- [x] Type check passes
- [x] Unit tests pass (291 passed, 5 pre-existing skips)
- [x] Lint passes
- [x] All 4 new test cases covering: injection triggers generation, no injection = no generation, error gracefully handled, no duplicate generation when thumbnail exists

## Validation

```bash
cd backend
npm run type-check
npm test -- --testPathPattern="videoService" --no-coverage
npm run lint
```

## Issue

Fixes #267

---

<details>
<summary>📋 Implementation Details</summary>

### Implementation followed artifact:

Investigation comment on issue #267

### Deviations from plan:

- `exactOptionalPropertyTypes: true` in tsconfig required `if (thumbnailService) { this.thumbnailService = thumbnailService; }` instead of direct assignment — semantically identical, TypeScript-safe.
- Auto-regeneration is synchronous (awaits `generateThumbnail`) rather than via a queue, which is simpler and consistent with the investigation's Option B (full consistency) intent. The health probe will block slightly longer on first scan for missing thumbnails, which is acceptable given health probes run infrequently.

</details>

---

_Automated implementation from investigation artifact_