### PR TITLE
Fix: invalidate thumbnailCache after auto-regeneration (#275)

### DIFF
--- a/backend/src/__tests__/unit/services/videoService.test.ts
+++ b/backend/src/__tests__/unit/services/videoService.test.ts
@@ -738,11 +738,11 @@ describe('VideoService', () => {
       mockThumbnailService.generateThumbnail.mockResolvedValue('/test/videos/video1.jpg');
 
       mockFs.access.mockResolvedValue(undefined);
-      // readdir: first call lists video files, then two calls for findThumbnailsBatch and findThumbnail fallback
+      // readdir: directory listing + findThumbnailsBatch (no thumbnails)
+      // After fix: return value from generateThumbnail() is used directly — no extra readdir call
       mockFs.readdir
         .mockResolvedValueOnce(['video1.mp4'] as any)   // directory listing
-        .mockResolvedValueOnce([] as any)               // findThumbnailsBatch: no thumbnails found
-        .mockResolvedValueOnce(['video1.jpg'] as any);  // findThumbnail after regeneration
+        .mockResolvedValueOnce([] as any);              // findThumbnailsBatch: no thumbnails found
       mockFs.stat.mockResolvedValue({
         isDirectory: () => false,
         isFile: () => true,
@@ -815,6 +815,73 @@ describe('VideoService', () => {
       await serviceWithThumb.scanVideoDirectory();
 
       expect(mockThumbnailService.generateThumbnail).not.toHaveBeenCalled();
+    });
+
+    it('should use return value of generateThumbnail() directly without re-scanning filesystem', async () => {
+      const serviceWithThumb = new VideoService(testVideosDir, mockThumbnailService as unknown as ThumbnailService);
+      mockThumbnailService.generateThumbnail.mockResolvedValue('/test/videos/video1.jpg');
+
+      mockFs.access.mockResolvedValue(undefined);
+      mockFs.readdir
+        .mockResolvedValueOnce(['video1.mp4'] as any)
+        .mockResolvedValueOnce([] as any)              // findThumbnailsBatch: no thumbnails
+        .mockResolvedValueOnce([] as any);             // findTranscripts in extractMetadata
+      mockFs.stat.mockResolvedValue({
+        isDirectory: () => false,
+        isFile: () => true,
+        size: 1000000,
+        mtime: new Date('2024-01-01')
+      } as any);
+
+      const result = await serviceWithThumb.scanVideoDirectory();
+
+      // Thumbnail from return value should appear in metadata (no extra filesystem round-trip needed)
+      expect(result.videos[0]?.metadata.thumbnail).toBe('video1.jpg');
+      // Exactly 3 readdir calls: directory listing + findThumbnailsBatch + findTranscripts
+      // (no 4th call for re-scanning thumbnail via findThumbnail)
+      expect(mockFs.readdir).toHaveBeenCalledTimes(3);
+    });
+
+    it('should invalidate thumbnailCache after successful thumbnail generation', async () => {
+      const serviceWithThumb = new VideoService(testVideosDir, mockThumbnailService as unknown as ThumbnailService);
+      mockThumbnailService.generateThumbnail.mockResolvedValue('/test/videos/video1.jpg');
+
+      mockFs.access.mockResolvedValue(undefined);
+      mockFs.stat.mockResolvedValue({
+        isDirectory: () => false,
+        isFile: () => true,
+        size: 1000000,
+        mtime: new Date('2024-01-01')
+      } as any);
+
+      // First scan: no thumbnail → generates one → cache invalidated
+      mockFs.readdir
+        .mockResolvedValueOnce(['video1.mp4'] as any)     // directory listing
+        .mockResolvedValueOnce([] as any)                 // findThumbnailsBatch: no thumbnails
+        .mockResolvedValueOnce([] as any);                // findTranscripts
+      await serviceWithThumb.scanVideoDirectory();
+      expect(mockThumbnailService.generateThumbnail).toHaveBeenCalledTimes(1);
+      jest.clearAllMocks();
+      mockFs.readFile.mockRejectedValue(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }));
+
+      // Second scan: cache was invalidated, readdir is called again; now thumbnail is present
+      mockFs.access.mockResolvedValue(undefined);
+      mockFs.stat.mockResolvedValue({
+        isDirectory: () => false,
+        isFile: () => true,
+        size: 1000000,
+        mtime: new Date('2024-01-01')
+      } as any);
+      mockFs.readdir
+        .mockResolvedValueOnce(['video1.mp4'] as any)               // directory listing
+        .mockResolvedValueOnce(['video1.mp4', 'video1.jpg'] as any) // findThumbnailsBatch: thumbnail present
+        .mockResolvedValueOnce([] as any);                          // findTranscripts
+      await serviceWithThumb.scanVideoDirectory();
+
+      // Thumbnail already present → no regeneration needed
+      expect(mockThumbnailService.generateThumbnail).not.toHaveBeenCalled();
+      // readdir IS called (cache was invalidated): directory listing + findThumbnailsBatch + findTranscripts
+      expect(mockFs.readdir).toHaveBeenCalledTimes(3);
     });
   });
 });

--- a/backend/src/services/videoService.ts
+++ b/backend/src/services/videoService.ts
@@ -84,12 +84,15 @@ export class VideoService {
         for (const videoFile of videoFiles) {
           if (!thumbnailMap.has(videoFile.path)) {
             try {
-              await this.thumbnailService.generateThumbnail(videoFile.path);
-              // Re-scan to pick up the newly generated thumbnail
-              const newThumbnail = await this.findThumbnail(videoFile.path);
-              if (newThumbnail) {
-                thumbnailMap.set(videoFile.path, newThumbnail);
-              }
+              const generatedPath = await this.thumbnailService.generateThumbnail(videoFile.path);
+              logger.info('Auto-regenerated missing thumbnail', { videoFile: videoFile.path, generatedPath });
+
+              // Invalidate cache so the next scan reads fresh thumbnail state
+              const dir = path.dirname(videoFile.path);
+              this.thumbnailCache.delete(dir);
+
+              // Use the returned path directly instead of re-scanning the filesystem
+              thumbnailMap.set(videoFile.path, path.basename(generatedPath));
             } catch (error) {
               const errorMessage = getErrorMessage(error);
               errors.push(`Failed to generate thumbnail for ${videoFile.name}: ${errorMessage}`);


### PR DESCRIPTION
## Summary

Within the 5-minute TTL window, `scanVideoDirectory()` was reading the stale cached directory listing after `generateThumbnail()` succeeded. This caused every subsequent scan within the TTL window to incorrectly detect the thumbnail as missing and attempt to regenerate it again — leading to redundant FFmpeg invocations, misleading logs, and potential race conditions.

## Root Cause

After `generateThumbnail()` succeeded, the code called `findThumbnail()` (which re-scans the filesystem via `access()` / `readdir()`) but **never called `this.thumbnailCache.delete(dir)`**. The next call to `getOrScanDirectory()` (used by `findThumbnailsBatch()`) returned the stale cached directory listing from before the thumbnail was created.

## Changes

| File | Change |
|------|--------|
| `backend/src/services/videoService.ts` | Add `thumbnailCache.delete(dir)` after successful generation; use `generateThumbnail()` return value directly instead of re-scanning |
| `backend/src/__tests__/unit/services/videoService.test.ts` | Add 2 new tests: return-value optimization and cache invalidation; update existing test comment to reflect no extra re-scan |

## Testing

- [x] Type check passes
- [x] Unit tests pass (56 passed, 0 failed)
- [x] Full test suite passes (293 passed, 5 skipped)
- [x] Lint passes
- [x] Build passes

## Validation

```bash
cd backend && npm run type-check && npm test -- --testPathPattern="videoService" --no-coverage && npm run lint
```

## Issue

Fixes #275

---

<details>
<summary>Implementation Details</summary>

### Deviations from plan:

- **Step 2 (api.ts / probes.ts / singleton)** was already addressed by PR #272 for `api.ts`, and the singleton/probes issues are tracked separately in #273 and #274. Only the core cache invalidation bug (Step 1) was in scope for #275.
- The plan's Step 1 "current constructor" snippet was outdated (PR #272 already added `ThumbnailService` support). Only the auto-regeneration loop change was needed.

</details>

---

_Automated implementation from investigation artifact_