### PR TITLE
Fix: inject ThumbnailService into videoService singleton (#274)

### DIFF
--- a/backend/src/services/videoService.ts
+++ b/backend/src/services/videoService.ts
@@ -419,9 +419,17 @@ export class VideoService {
 }
 
 /**
+ * Shared thumbnail service instance for the default video service singleton.
+ * Kept separate from services/index.ts to avoid circular dependencies.
+ */
+const defaultThumbnailService = new ThumbnailService(config.tempDir);
+
+/**
  * Default video service instance
- * Uses environment variable or default path
+ * Uses environment variable or default path.
+ * Injects ThumbnailService to enable auto-regeneration of missing thumbnails.
  */
 export const videoService = new VideoService(
-  config.videosDir
+  config.videosDir,
+  defaultThumbnailService
 );


### PR DESCRIPTION
## Summary

The default `videoService` singleton in `backend/src/services/videoService.ts` was instantiated without `ThumbnailService`, causing auto-regeneration of missing thumbnails to be silently disabled for all consumers of the default export. Any module importing the canonical `videoService` singleton got a version without auto-regeneration capability.

## Root Cause

The singleton export at the end of `videoService.ts` only passed `config.videosDir` to the constructor, omitting the optional `thumbnailService` parameter that enables the auto-regeneration path. The `VideoService` constructor and the class-level auto-regeneration logic were already correctly implemented — only the singleton wiring was missing.

## Changes

| File | Change |
|------|--------|
| `backend/src/services/videoService.ts` | Added `defaultThumbnailService` instance and injected it into the `videoService` singleton export |

## Testing

- [x] Type check passes (`npm run type-check`)
- [x] Unit tests pass — 56 videoService tests, 301 total tests (296 passed, 5 skipped)
- [x] Lint passes (`npm run lint`)
- [x] Pre-push validation passed (lint + type-check + build)

## Validation

```bash
cd backend
npm run type-check
npm test -- --testPathPattern="videoService" --no-coverage
npm run lint
```

## Issue

Fixes #274

---

<details>
<summary>Implementation Details</summary>

### Deviations from plan:

Steps 1 and 3 from the investigation artifact were already implemented in the codebase (constructor already accepted optional `ThumbnailService`, and tests already covered ThumbnailService injection). Only Step 2 (singleton wiring) was missing and has been applied.

The `defaultThumbnailService` is instantiated directly in `videoService.ts` using the already-imported `ThumbnailService` class (not from `services/index.ts`) to avoid any risk of circular dependencies.

</details>

---

_Automated implementation from investigation artifact (issue #274 comment)_