### PR TITLE
Fix: keep health probe read-only by removing thumbnailService injection (#273)

### DIFF
--- a/backend/src/routes/health/probes.ts
+++ b/backend/src/routes/health/probes.ts
@@ -4,7 +4,6 @@ import os from 'os';
 import path from 'path';
 import { config } from '../../config';
 import { logger } from '../../utils/logger';
-import { thumbnailService } from '../../services';
 import { DirectoryDiskSpace, DirectoryHealth, VideoServiceHealth } from './types';
 
 const DISK_SPACE_WARNING_THRESHOLD = 0.9;
@@ -108,7 +107,10 @@ export async function getVideoServiceHealth(): Promise<VideoServiceHealth> {
 
   try {
     const { VideoService } = await import('../../services/videoService');
-    const videoService = new VideoService(getVideosDirectory(), thumbnailService);
+    // Keep health probe intentionally read-only — auto-regeneration is a maintenance
+    // task, not a liveness check. Health probes must return in milliseconds, not
+    // trigger expensive FFmpeg thumbnail generation. See: api.ts for the scan path.
+    const videoService = new VideoService(getVideosDirectory());
     const result = await videoService.scanVideoDirectory();
 
     health.lastScan = new Date().toISOString();


### PR DESCRIPTION
## Summary

After PR #272 merged, `getVideoServiceHealth()` in `backend/src/routes/health/probes.ts` passed `thumbnailService` to `VideoService`, causing `scanVideoDirectory()` to run N sequential FFmpeg invocations (one per missing thumbnail) **synchronously before returning the health-probe response**. On a library with many videos missing thumbnails, this can take minutes, causing Docker/k8s liveness probe failures and container restart loops.

## Root Cause

Health probes are liveness checks expected to return in milliseconds. Passing `thumbnailService` to `VideoService` in the health probe context triggers the auto-regeneration path, which is a maintenance task — not a liveness check. The injection was correctly applied to `api.ts` (production scan path) but incorrectly also applied to `probes.ts`.

## Changes

| File | Change |
|------|--------|
| `backend/src/routes/health/probes.ts` | Remove `thumbnailService` import and argument from `VideoService` constructor in `getVideoServiceHealth()`. Add explanatory comment for future maintainers. |

## Testing

- [x] Type check passes
- [x] Unit tests pass (296 backend + 170 frontend, 0 failures)
- [x] Lint passes
- [x] Pre-push hook: lint, type-check, build all green

## Validation

```bash
cd backend
npm run type-check && npm test -- --testPathPattern="videoService|probes|health" && npm run lint
```

## Issue

Fixes #273

---

<details>
<summary>Implementation Details</summary>

### Implementation followed artifact:

Investigation comment on issue #273 (posted by GHAR, 2026-03-31T00:35:00Z)

### Deviations from plan:

None — implemented exactly as specified in the investigation comment.

</details>

---

_Automated implementation from investigation artifact_