### PR TITLE
Fix: getDiskSpaceInfo reports actual disk space via fs.statfsSync (#279)

### DIFF
--- a/backend/src/__tests__/unit/probes.test.ts
+++ b/backend/src/__tests__/unit/probes.test.ts
@@ -1,0 +1,76 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+// Mock logger to avoid fs issues during winston initialization
+jest.mock('../../utils/logger', () => ({
+  logger: {
+    info: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn()
+  }
+}));
+
+// Mock config to avoid environment issues
+jest.mock('../../config', () => ({
+  config: {
+    videosDir: '/tmp/test-videos',
+    tempDir: '/tmp/test-temp'
+  }
+}));
+
+import { getDiskSpaceInfo } from '../../routes/health/probes';
+
+describe('probes', () => {
+  describe('getDiskSpaceInfo', () => {
+    it('should return actual disk space for a valid directory', async () => {
+      const result = await getDiskSpaceInfo('/');
+
+      expect(result).toBeDefined();
+      expect(result!.total).toBeGreaterThan(0);
+      expect(result!.free).toBeGreaterThanOrEqual(0);
+      expect(result!.used).toBeGreaterThanOrEqual(0);
+      expect(result!.usagePercent).toBeGreaterThanOrEqual(0);
+      expect(result!.usagePercent).toBeLessThanOrEqual(100);
+    });
+
+    it('should return correct usagePercent calculation', async () => {
+      const result = await getDiskSpaceInfo('/tmp');
+
+      expect(result).toBeDefined();
+      expect(result!.usagePercent).toBe(Math.round((result!.used / result!.total) * 100));
+    });
+
+    it('should return status based on thresholds', async () => {
+      const result = await getDiskSpaceInfo('/');
+
+      expect(['ok', 'warning', 'critical']).toContain(result!.status);
+    });
+
+    it('should return undefined for non-existent path', async () => {
+      const result = await getDiskSpaceInfo('/nonexistent/path/that/does/not/exist');
+
+      expect(result).toBeUndefined();
+    });
+
+    it('should use the dirPath parameter to query correct filesystem', async () => {
+      const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'test-disk-space-'));
+
+      try {
+        const result = await getDiskSpaceInfo(tempDir);
+
+        expect(result).toBeDefined();
+      } finally {
+        fs.rmSync(tempDir, { recursive: true, force: true });
+      }
+    });
+
+    it('should not return memory metrics (total should differ from os.totalmem)', async () => {
+      const result = await getDiskSpaceInfo('/');
+
+      // Memory multiplied by 10 was the old bug — disk space should not equal memory*10
+      expect(result!.total).not.toBe(os.totalmem() * 10);
+    });
+  });
+});

--- a/backend/src/routes/health/probes.ts
+++ b/backend/src/routes/health/probes.ts
@@ -75,8 +75,12 @@ export async function getDirectoryHealth(dirPath: string): Promise<DirectoryHeal
 
 export async function getDiskSpaceInfo(dirPath: string): Promise<DirectoryDiskSpace | undefined> {
   try {
-    const totalSpace = os.totalmem() * 10;
-    const freeSpace = os.freemem() * 10;
+    const stats = fs.statfsSync(dirPath);
+    const blockSize = stats.bsize;
+    const totalSpace = blockSize * stats.blocks;
+    // Use bavail (not bfree) to match what df reports: blocks available to
+    // unprivileged processes, excluding root-reserved blocks (~5% on ext4).
+    const freeSpace = blockSize * stats.bavail;
     const usedSpace = totalSpace - freeSpace;
     const usagePercent = usedSpace / totalSpace;
 


### PR DESCRIPTION
## Summary

The `getDiskSpaceInfo(dirPath)` function in `backend/src/routes/health/probes.ts` was returning `os.totalmem() * 10` and `os.freemem() * 10` labelled as disk space metrics, silently misleading operators about actual disk capacity. The `dirPath` parameter was accepted but never used.

## Root Cause

Missing implementation: function body was copy-pasted from or confused with memory reporting logic. The `dirPath` parameter existed for API compatibility but was never passed to any filesystem syscall.

## Changes

| File | Change |
|------|--------|
| `backend/src/routes/health/probes.ts` | Replace `os.totalmem/freemem * 10` with `fs.statfsSync(dirPath)` to query real filesystem statistics |
| `backend/src/__tests__/unit/probes.test.ts` | Created — 6 unit tests covering real disk stats, correct calculation, threshold status, error path, tmpdir path, and adversarial regression against old memory*10 value |

## Testing

- [x] Type check passes
- [x] Unit tests pass (19/19 suites, 244/245 tests)
- [x] Lint passes
- [x] Pre-push hook (lint + type-check + build) all green

## Validation

```bash
cd backend
npm run type-check && npm run test:unit && npm run lint
```

## Issue

Fixes #279

---

<details>
<summary>Implementation Details</summary>

### Implementation followed artifact from issue investigation comment

### Deviations from plan:

- Added an extra adversarial test case (`should not return memory metrics`) beyond the 5 cases in the artifact to explicitly document and guard against regression to the original bug.

</details>

---

_Automated implementation from investigation artifact_