### PR TITLE
Fix: honour FFMPEG_PATH env var in resolveFfmpegBinary() (#287)

### DIFF
--- a/backend/src/__tests__/unit/services/thumbnailService.test.ts
+++ b/backend/src/__tests__/unit/services/thumbnailService.test.ts
@@ -188,3 +188,68 @@ describe('ThumbnailService Configuration', () => {
     expect(() => nodeFs.accessSync(ffmpegStatic, nodeFs.constants.X_OK)).not.toThrow();
   });
 });
+
+describe('resolveFfmpegBinary - FFMPEG_PATH override', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('should use FFMPEG_PATH env var as first candidate when set to an executable path', async () => {
+    const customPath = '/custom/ffmpeg';
+    process.env = { ...originalEnv, FFMPEG_PATH: customPath };
+
+    const capturedArgs: string[] = [];
+    jest.doMock('fs/promises', () => ({
+      // Allow all access checks to pass (binary exists + thumbnail written)
+      access: jest.fn().mockResolvedValue(undefined),
+      mkdir: jest.fn().mockResolvedValue(undefined),
+    }));
+    jest.doMock('execa', () => {
+      const fn = jest.fn().mockImplementation((binary: string, _args: string[]) => {
+        capturedArgs.push(binary);
+        return Promise.resolve({ exitCode: 0 });
+      });
+      return fn;
+    });
+
+    const { ThumbnailService: IsolatedService } = require('../../../services/thumbnailService');
+    const service = new IsolatedService('/tmp');
+    await service.generateThumbnail('/test/video.mp4');
+
+    // The ffmpeg binary invoked for thumbnail generation must be the custom path
+    expect(capturedArgs).toContain(customPath);
+  });
+
+  it('should fall back to ffmpeg-static when FFMPEG_PATH is not set', async () => {
+    process.env = { ...originalEnv };
+    delete process.env.FFMPEG_PATH;
+
+    const ffmpegStaticPath = require('ffmpeg-static');
+    const capturedArgs: string[] = [];
+
+    jest.doMock('fs/promises', () => ({
+      access: jest.fn().mockResolvedValue(undefined),
+      mkdir: jest.fn().mockResolvedValue(undefined),
+    }));
+    jest.doMock('execa', () => {
+      const fn = jest.fn().mockImplementation((binary: string, _args: string[]) => {
+        capturedArgs.push(binary);
+        return Promise.resolve({ exitCode: 0 });
+      });
+      return fn;
+    });
+
+    const { ThumbnailService: IsolatedService } = require('../../../services/thumbnailService');
+    const service = new IsolatedService('/tmp');
+    await service.generateThumbnail('/test/video.mp4');
+
+    // Without FFMPEG_PATH override, ffmpeg-static path must be used
+    expect(capturedArgs).toContain(ffmpegStaticPath);
+  });
+});

--- a/backend/src/services/thumbnailService.ts
+++ b/backend/src/services/thumbnailService.ts
@@ -14,11 +14,11 @@ let resolutionPromise: Promise<string> | null = null;
 
 /**
  * Resolve an executable ffmpeg binary path.
- * Priority: ffmpeg-static path (if executable) → 'ffmpeg' on PATH → '/usr/bin/ffmpeg'
+ * Priority: FFMPEG_PATH env var (explicit override) → ffmpeg-static path → 'ffmpeg' on PATH → '/usr/bin/ffmpeg'
  * Throws AppError if none is found.
  */
 async function resolveFfmpegBinary(): Promise<string> {
-  const candidates = [ffmpegBin, 'ffmpeg', '/usr/bin/ffmpeg'].filter(Boolean) as string[];
+  const candidates = [process.env.FFMPEG_PATH, ffmpegBin, 'ffmpeg', '/usr/bin/ffmpeg'].filter(Boolean) as string[];
 
   for (const candidate of candidates) {
     try {


### PR DESCRIPTION
## Summary

`FFMPEG_PATH` was documented in `config.ts` and `README.md` as an explicit override for the FFmpeg binary path, but `resolveFfmpegBinary()` in `thumbnailService.ts` never consulted it. Users in constrained environments relying on this env var had their configuration silently ignored.

## Root Cause

`resolveFfmpegBinary()` was implemented in PR #283 without consulting the existing config schema. The candidates array only included `ffmpeg-static`, `'ffmpeg'` (PATH lookup), and `/usr/bin/ffmpeg` — omitting the documented `FFMPEG_PATH` override entirely.

## Changes

| File | Change |
|------|--------|
| `backend/src/services/thumbnailService.ts` | Add `process.env.FFMPEG_PATH` as first candidate in `resolveFfmpegBinary()`; update JSDoc to document priority order |
| `backend/src/__tests__/unit/services/thumbnailService.test.ts` | Add 2 tests: FFMPEG_PATH override is used when set; ffmpeg-static fallback when not set |

## Testing

- [x] Type check passes
- [x] Unit tests pass (310 total, 305 passed, 5 pre-existing skips)
- [x] Lint passes
- [x] Integration tests pass

## Validation

```bash
cd backend && npm run type-check
cd backend && npm test -- --testPathPattern="thumbnailService" --no-coverage
cd backend && npm run lint
```

## Issue

Fixes #287

---

<details>
<summary>Implementation Details</summary>

### Deviation from investigation artifact

The artifact expected no `resolveFfmpegBinary()` function to exist and planned to create one. However, the function was already added in commit `ebf5afc` (PR #283) before this fix was implemented. The adaptation was minimal: instead of creating the function, only one line was changed — adding `process.env.FFMPEG_PATH` as the first element of the existing candidates array.

The artifact suggested using `config.ffmpegPath`, but this was correctly avoided since `config.ffmpegPath` always has a value (defaults to `/usr/bin/ffmpeg`), which would change the resolution priority even when no env var is set. Using `process.env.FFMPEG_PATH` directly ensures the override only applies when explicitly set.

</details>

---

_Automated implementation from investigation artifact_