### PR TITLE
Fix: strengthen FFMPEG_PATH priority assertion toContain → toBe (#290)

### DIFF
--- a/backend/src/__tests__/unit/services/thumbnailService.test.ts
+++ b/backend/src/__tests__/unit/services/thumbnailService.test.ts
@@ -223,7 +223,8 @@ describe('resolveFfmpegBinary - FFMPEG_PATH override', () => {
     await service.generateThumbnail('/test/video.mp4');
 
     // The ffmpeg binary invoked for thumbnail generation must be the custom path
-    expect(capturedArgs).toContain(customPath);
+    // Use [0] to verify FFMPEG_PATH is tried FIRST (highest priority), not just included somewhere
+    expect(capturedArgs[0]).toBe(customPath);
   });
 
   it('should fall back to ffmpeg-static when FFMPEG_PATH is not set', async () => {
@@ -249,7 +250,7 @@ describe('resolveFfmpegBinary - FFMPEG_PATH override', () => {
     const service = new IsolatedService('/tmp');
     await service.generateThumbnail('/test/video.mp4');
 
-    // Without FFMPEG_PATH override, ffmpeg-static path must be used
-    expect(capturedArgs).toContain(ffmpegStaticPath);
+    // Without FFMPEG_PATH override, ffmpeg-static path must be used as first candidate
+    expect(capturedArgs[0]).toBe(ffmpegStaticPath);
   });
 });


### PR DESCRIPTION
## Summary

The test at `thumbnailService.test.ts:226` used `toContain()` which only checks array membership, not position. `FFMPEG_PATH` must be the *first* resolution candidate to honour the highest-priority override contract; `toContain` would pass even if the custom path appeared at index 1 or later after a future refactor.

## Root Cause

`toContain` checks membership in the `capturedArgs` array but not ordering. Since `FFMPEG_PATH` must be the **first** candidate tried, a position-unaware assertion is misleading and will not catch priority-order regressions.

## Changes

| File | Change |
|------|--------|
| `backend/src/__tests__/unit/services/thumbnailService.test.ts` | Replace `toContain(customPath)` → `capturedArgs[0].toBe(customPath)` (line 226, required) |
| `backend/src/__tests__/unit/services/thumbnailService.test.ts` | Replace `toContain(ffmpegStaticPath)` → `capturedArgs[0].toBe(ffmpegStaticPath)` (line 253, consistency) |

## Testing

- [x] Type check passes
- [x] Unit tests pass (16 passed, 1 skipped — pre-existing skip)
- [x] Lint passes
- [x] Full test suite passes (305 passed, 5 skipped, 310 total)

## Validation

```bash
cd backend && npm run type-check
cd backend && npm test -- --testPathPattern="thumbnailService" --no-coverage
cd backend && npm run lint
```

## Issue

Fixes #290

---

<details>
<summary>Implementation Details</summary>

### Implementation followed artifact:

Investigation comment on issue #290

### Deviations from plan:

Step 2 (fallback test at line 253) was listed as optional in the investigation plan but applied here for consistency — the assertion is equally correct and prevents similar silent failures in the fallback path.

</details>

---

_Automated implementation from investigation artifact_