### PR TITLE
Fix: correct FFMPEG_PATH and FFPROBE_PATH descriptions in README.md (#289)

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,8 +206,8 @@ cp backend/.env.example backend/.env
 | `ALLOWED_ORIGINS` | `http://localhost:5183` | Comma-separated CORS allowlist for production |
 | `THUMBNAIL_MAX_SIZE` | `10485760` (10MB) | Maximum thumbnail size in bytes; larger files return HTTP 413; inaccessible thumbnail files return HTTP 403 |
 | `THUMBNAIL_CACHE_DURATION` | `86400` | Thumbnail cache max-age in seconds |
-| `FFMPEG_PATH` | `/usr/bin/ffmpeg` | FFmpeg binary path used when static binary is unavailable |
-| `FFPROBE_PATH` | `/usr/bin/ffprobe` | FFprobe binary path used when static binary is unavailable |
+| `FFMPEG_PATH` | `/usr/bin/ffmpeg` | FFmpeg binary path override (highest priority; takes precedence over ffmpeg-static and system PATH) |
+| `FFPROBE_PATH` | `/usr/bin/ffprobe` | FFprobe binary path (falls back to /usr/bin/ffprobe if unset) |
 
 ## Requirements
 


### PR DESCRIPTION
## Summary

README.md still described `FFMPEG_PATH` as a fallback (used when static binary unavailable). After PR #288 merged, `FFMPEG_PATH` is now the **highest-priority override** in `resolveFfmpegBinary()` — not a fallback. This creates a false contract that could cause production misconfiguration.

## Root Cause

PR #288 only changed `thumbnailService.ts` and its tests — README was not updated. Issue #287 explicitly listed README sync as a required fix alongside the code change, but was deferred.

## Changes

| File | Change |
|------|--------|
| `README.md` | Updated `FFMPEG_PATH` description to "FFmpeg binary path override (highest priority; takes precedence over ffmpeg-static and system PATH)" |
| `README.md` | Updated `FFPROBE_PATH` description to "FFprobe binary path (falls back to /usr/bin/ffprobe if unset)" |

## Testing

- [x] Type check passes
- [x] Unit tests pass (305 passed, 5 skipped)
- [x] Frontend tests pass
- [x] Lint passes
- [x] Manual verification: README.md line 209-210 now correctly describes override/fallback semantics

## Validation

```bash
make lint && make test
```

## Issue

Fixes #289

---

<details>
<summary>Implementation Details</summary>

### Implementation followed artifact:

Investigation comment on issue #289

### Deviations from plan:

None — both steps implemented exactly as specified.

</details>

---

_Automated implementation from investigation artifact_