### PR TITLE
Fix: remove misleading it.skip real-ffmpeg unit test (#286)

### DIFF
--- a/backend/src/__tests__/unit/services/thumbnailService.test.ts
+++ b/backend/src/__tests__/unit/services/thumbnailService.test.ts
@@ -128,7 +128,7 @@ describe('ThumbnailService', () => {
 });
 
 // Real FFmpeg Integration Tests (no mocks)
-describe('ThumbnailService - Real FFmpeg Integration', () => {
+describe('ThumbnailService - Real FFmpeg (error paths)', () => {
   const { ThumbnailService: RealThumbnailService } = jest.requireActual('../../../services/thumbnailService');
   let realService: any;
   const tempDir = '/tmp/test-thumbnails';
@@ -155,7 +155,7 @@ describe('ThumbnailService - Real FFmpeg Integration', () => {
   it('should handle non-existent video file gracefully', async () => {
     await expect(
       realService.generateThumbnail('/nonexistent/video.mp4')
-    ).rejects.toThrow();
+    ).rejects.toThrow('Failed to generate thumbnail');
   });
 });
 

--- a/dev/state/task-ledger.json
+++ b/dev/state/task-ledger.json
@@ -272,6 +272,19 @@
     ],
     "last_verified": "2026-03-31T04:25:00Z"
   },
+  "PR_297_CODE_REVIEW_SUGGESTIONS": {
+    "status": "in_progress",
+    "evidence": [
+      "Issue #286 latest open; PR #297 (fix/issue-286-remove-skip-ffmpeg-unit-test) linked",
+      "Automated code review identified 2 non-blocking suggestions:",
+      "1. thumbnailService.test.ts:131 - rename describe 'ThumbnailService - Real FFmpeg Integration' -> 'ThumbnailService - Real FFmpeg (error paths)'",
+      "2. thumbnailService.test.ts:155 - tighten .rejects.toThrow() -> .rejects.toThrow('Failed to generate thumbnail')",
+      "5xWhy RCA: Why1: describe block name misleading (only error-path test inside). Why2: it.skip real-ffmpeg test was removed so describe title no longer accurate. Why3: Original title described integration intent not actual content. Why4: Single test covers only error path (non-existent file). Why5: Self-documenting title required for clarity.",
+      "Fix applied: Edit thumbnailService.test.ts lines 131 and 158",
+      "Verification: cd backend && npm test -- --testPathPattern=thumbnailService --no-coverage -> 16 passed, 0 skipped (2026-03-31)"
+    ],
+    "last_verified": "2026-03-31T12:15:00Z"
+  },
   "PR_265_MERGE_CONFLICT_V2": {
     "status": "in_progress",
     "evidence": [


### PR DESCRIPTION
## Summary

An `it.skip` block in `thumbnailService.test.ts` (lines 161-171) provided zero test coverage (permanently skipped) and used a catch-all assertion `expect(error).toBeDefined()` that would pass for any thrown value, including test infrastructure errors unrelated to ffmpeg. This constitutes test theater.

## Root Cause

The test was added as a placeholder for real-ffmpeg integration testing but was skipped before completion. The catch block assertion is meaningless, accepting any thrown value. Real-ffmpeg coverage is already provided by `thumbnail-regeneration.integration.test.ts` with stronger assertions (actual `.jpg` file verified on disk).

## Changes

| File | Change |
|------|--------|
| `backend/src/__tests__/unit/services/thumbnailService.test.ts` | Removed `it.skip` block (11 lines, lines 161-171) |

## Testing

- [x] Type check passes
- [x] Unit tests pass (16/16 in thumbnailService, 305/305 backend total)
- [x] Lint passes
- [x] Frontend tests pass (170/170)
- [x] Integration test `thumbnail-regeneration.integration.test.ts` still runs and passes

## Validation

```bash
cd backend && npm test -- --testPathPattern="thumbnailService" --no-coverage
# Expected: 16 tests pass, 0 skipped
```

## Issue

Fixes #286

---

<details>
<summary>Implementation Details</summary>

### Implementation followed artifact:

Investigation comment on issue #286 (by GHAR, 2026-03-31)

### Deviations from plan:

None

</details>

---

_Automated implementation from investigation artifact_