### PR TITLE
Fix: isExecutable() returns true for directories (#299)

### DIFF
--- a/backend/scripts/postinstall.js
+++ b/backend/scripts/postinstall.js
@@ -7,6 +7,8 @@ const ROOT = path.resolve(__dirname, '..');
 
 function isExecutable(filePath) {
   try {
+    const stat = fs.statSync(filePath);
+    if (!stat.isFile()) return false;
     fs.accessSync(filePath, fs.constants.X_OK);
     return true;
   } catch {


### PR DESCRIPTION
## Summary

The `isExecutable` function in `backend/scripts/postinstall.js` uses `fs.accessSync(filePath, fs.constants.X_OK)` to check executability. On Linux/macOS, the `X_OK` bit on a directory means \"traversable\", not \"executable binary\". If the binary path is accidentally a directory (e.g., corrupt npm install), the guard returns `true` — skipping symlink creation — but spawning the path would fail at runtime with a cryptic error.

## Root Cause

On Unix-like systems, the execute permission bit (`X_OK`) has different meanings for files vs directories:
- **Files**: Requires execute permission to run as a binary
- **Directories**: Requires execute permission to traverse (enter) the directory

The original `isExecutable` function did not distinguish between these cases. A traversable directory would pass the `accessSync(X_OK)` check, incorrectly returning `true`.

## Changes

| File | Change |
|------|--------|
| `backend/scripts/postinstall.js` | Add `fs.statSync(filePath).isFile()` guard before `accessSync(X_OK)` in `isExecutable` |

## Testing

- [x] `node scripts/postinstall.js` runs cleanly
- [x] Adversarial test: replaced yt-dlp symlink with directory — now correctly returns "not found or not executable" instead of silently returning true
- [x] Lint passes
- [x] All 305 backend tests pass
- [x] All frontend tests pass
- [x] Type check passes
- [x] Build validation passes

## Validation

```bash
cd backend
node scripts/postinstall.js
npm run lint
npm test
```

## Issue

Fixes #299

---

<details>
<summary>Implementation Details</summary>

### Implementation followed artifact from investigation comment on issue #299

### Deviations from plan:

None — implemented exactly as specified.

</details>

---

_Automated implementation from investigation artifact_