### PR TITLE
Fix: run cleanup before queue processing (#319)

### DIFF
--- a/backend/src/__tests__/unit/services/downloadQueueService.test.ts
+++ b/backend/src/__tests__/unit/services/downloadQueueService.test.ts
@@ -136,6 +136,46 @@ describe('DownloadQueueService', () => {
 
       expect(mockDownloadVideo).toHaveBeenCalledTimes(1);
     });
+
+    it('should not run video resource cleanup while processing is active', async () => {
+      let finishDownload: (() => void) | undefined;
+      mockDownloadVideo.mockImplementationOnce(() => new Promise((resolve) => {
+        finishDownload = () => resolve({
+          status: 'success',
+          videoPath: '/test/output/video.mp4'
+        });
+      }));
+      const cleanupOldResources = jest.fn().mockResolvedValue(0);
+      const cleanupService = { cleanupOldResources } as unknown as VideoCleanupService;
+      const serviceWithCleanup = new DownloadQueueService('/test/temp', mockYoutubeService, cleanupService);
+      mockReadFile.mockRejectedValue(new Error('File not found'));
+      await serviceWithCleanup.initialize();
+
+      await serviceWithCleanup.addToQueue({
+        url: 'https://youtu.be/test-video-1',
+        requestId: 'req-1',
+        requestedAt: new Date()
+      });
+      await new Promise((resolve) => setImmediate(resolve));
+
+      expect(cleanupOldResources).toHaveBeenCalledTimes(1);
+      expect(mockDownloadVideo).toHaveBeenCalledTimes(1);
+
+      await serviceWithCleanup.addToQueue({
+        url: 'https://youtu.be/test-video-2',
+        requestId: 'req-2',
+        requestedAt: new Date()
+      });
+
+      expect(cleanupOldResources).toHaveBeenCalledTimes(1);
+
+      if (!finishDownload) {
+        throw new Error('Expected download promise to be created');
+      }
+
+      finishDownload();
+      await new Promise((resolve) => setImmediate(resolve));
+    });
   });
 
   describe('cancelDownload', () => {

--- a/backend/src/__tests__/unit/services/downloadQueueService.test.ts
+++ b/backend/src/__tests__/unit/services/downloadQueueService.test.ts
@@ -137,6 +137,43 @@ describe('DownloadQueueService', () => {
       expect(mockDownloadVideo).toHaveBeenCalledTimes(1);
     });
 
+    it('should share pending startup cleanup across concurrent idle enqueues', async () => {
+      let finishCleanup: (() => void) | undefined;
+      const cleanupOldResources = jest.fn().mockImplementationOnce(() => new Promise<void>((resolve) => {
+        finishCleanup = resolve;
+      }));
+      const cleanupService = { cleanupOldResources } as unknown as VideoCleanupService;
+      const serviceWithCleanup = new DownloadQueueService('/test/temp', mockYoutubeService, cleanupService);
+      mockReadFile.mockRejectedValue(new Error('File not found'));
+      await serviceWithCleanup.initialize();
+
+      const firstAdd = serviceWithCleanup.addToQueue({
+        url: 'https://youtu.be/test-video-1',
+        requestId: 'req-1',
+        requestedAt: new Date()
+      });
+      const secondAdd = serviceWithCleanup.addToQueue({
+        url: 'https://youtu.be/test-video-2',
+        requestId: 'req-2',
+        requestedAt: new Date()
+      });
+
+      await new Promise((resolve) => setImmediate(resolve));
+
+      expect(cleanupOldResources).toHaveBeenCalledTimes(1);
+      expect(mockDownloadVideo).not.toHaveBeenCalled();
+
+      if (!finishCleanup) {
+        throw new Error('Expected cleanup promise to be created');
+      }
+
+      finishCleanup();
+      await Promise.all([firstAdd, secondAdd]);
+      await new Promise((resolve) => setImmediate(resolve));
+
+      expect(mockDownloadVideo).toHaveBeenCalledTimes(2);
+    });
+
     it('should not run video resource cleanup while processing is active', async () => {
       let finishDownload: (() => void) | undefined;
       mockDownloadVideo.mockImplementationOnce(() => new Promise((resolve) => {

--- a/backend/src/__tests__/unit/services/downloadQueueService.test.ts
+++ b/backend/src/__tests__/unit/services/downloadQueueService.test.ts
@@ -104,20 +104,37 @@ describe('DownloadQueueService', () => {
       expect(status.totalItems).toBe(1);
     });
 
-    it('should trigger video resource cleanup after adding to queue', async () => {
+    it('should trigger video resource cleanup before processing the queue', async () => {
+      let finishCleanup: (() => void) | undefined;
       const cleanupOldResources = jest.fn().mockResolvedValue(0);
+      cleanupOldResources.mockImplementationOnce(() => new Promise<void>((resolve) => {
+        finishCleanup = resolve;
+      }));
       const cleanupService = { cleanupOldResources } as unknown as VideoCleanupService;
       const serviceWithCleanup = new DownloadQueueService('/test/temp', mockYoutubeService, cleanupService);
       mockReadFile.mockRejectedValue(new Error('File not found'));
       await serviceWithCleanup.initialize();
 
-      await serviceWithCleanup.addToQueue({
+      const addPromise = serviceWithCleanup.addToQueue({
         url: 'https://youtu.be/test-video',
         requestId: 'req-1',
         requestedAt: new Date()
       });
 
+      await new Promise((resolve) => setImmediate(resolve));
+
       expect(cleanupOldResources).toHaveBeenCalledTimes(1);
+      expect(mockDownloadVideo).not.toHaveBeenCalled();
+
+      if (!finishCleanup) {
+        throw new Error('Expected cleanup promise to be created');
+      }
+
+      finishCleanup();
+      await addPromise;
+      await new Promise((resolve) => setImmediate(resolve));
+
+      expect(mockDownloadVideo).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/backend/src/services/downloadQueueService.ts
+++ b/backend/src/services/downloadQueueService.ts
@@ -28,6 +28,7 @@ export class DownloadQueueService {
   private readonly youtubeDownloadService: YouTubeDownloadService;
   private queue: QueueItem[] = [];
   private isProcessing = false;
+  private queueStartupPromise: Promise<void> | undefined;
 
   constructor(
     tempDirectory: string,
@@ -78,24 +79,12 @@ export class DownloadQueueService {
         queueSize: this.queue.length
       });
 
-      if (this.videoCleanupService) {
-        try {
-          await this.videoCleanupService.cleanupOldResources();
-        } catch (error) {
-          logger.error('Video resource cleanup failed', {
-            error: getErrorMessage(error)
-          });
-        }
+      if (!this.isProcessing && !this.queueStartupPromise) {
+        this.queueStartupPromise = this.startQueueProcessorAfterCleanup();
       }
 
-      // Clean up stale library resources before queue processing starts to avoid
-      // deleting freshly re-downloaded files with the same generated prefix.
-      if (!this.isProcessing) {
-        this.runQueueProcessor().catch(error => {
-          logger.error('Queue processing error', {
-            error: getErrorMessage(error)
-          });
-        });
+      if (this.queueStartupPromise) {
+        await this.queueStartupPromise;
       }
 
       return queueItem;
@@ -220,6 +209,32 @@ export class DownloadQueueService {
     } finally {
       this.isProcessing = false;
       logger.info('Queue processing stopped');
+    }
+  }
+
+  private async startQueueProcessorAfterCleanup(): Promise<void> {
+    try {
+      if (this.videoCleanupService) {
+        try {
+          await this.videoCleanupService.cleanupOldResources();
+        } catch (error) {
+          logger.error('Video resource cleanup failed', {
+            error: getErrorMessage(error)
+          });
+        }
+      }
+
+      // Clean up stale library resources before queue processing starts to avoid
+      // deleting freshly re-downloaded files with the same generated prefix.
+      if (!this.isProcessing) {
+        this.runQueueProcessor().catch(error => {
+          logger.error('Queue processing error', {
+            error: getErrorMessage(error)
+          });
+        });
+      }
+    } finally {
+      this.queueStartupPromise = undefined;
     }
   }
 

--- a/backend/src/services/downloadQueueService.ts
+++ b/backend/src/services/downloadQueueService.ts
@@ -78,18 +78,21 @@ export class DownloadQueueService {
         queueSize: this.queue.length
       });
 
-      // Start processing if not already running
+      if (this.videoCleanupService) {
+        try {
+          await this.videoCleanupService.cleanupOldResources();
+        } catch (error) {
+          logger.error('Video resource cleanup failed', {
+            error: getErrorMessage(error)
+          });
+        }
+      }
+
+      // Clean up stale library resources before queue processing starts to avoid
+      // deleting freshly re-downloaded files with the same generated prefix.
       if (!this.isProcessing) {
         this.runQueueProcessor().catch(error => {
           logger.error('Queue processing error', {
-            error: getErrorMessage(error)
-          });
-        });
-      }
-
-      if (this.videoCleanupService) {
-        this.videoCleanupService.cleanupOldResources().catch(error => {
-          logger.error('Video resource cleanup failed', {
             error: getErrorMessage(error)
           });
         });

--- a/dev/state/task-ledger.json
+++ b/dev/state/task-ledger.json
@@ -406,5 +406,18 @@
       "git rev-parse --verify HEAD && git rev-parse --verify origin/fix/issue-319-cleanup-race -> both 740f3430d9f1b4ba6cb5f887744aab06fb6c6451"
     ],
     "last_verified": "2026-05-18T19:03:00Z"
+  },
+  "resolve-pr-320-merge-issues-2026-05-18T191411Z": {
+    "status": "done",
+    "evidence": [
+      "Selected task after loading dev/state/task-ledger.json: verify and resolve PR #320 merge status for latest open issue #319",
+      "5xWhy RCA: Why1 PR appeared to have merge issues because earlier PR status was UNSTABLE; Why2 status was UNSTABLE because CI was still pending; Why3 CI was pending because the branch had just been updated; Why4 no code merge conflict existed because GitHub API now reports mergeable=true and mergeable_state=clean; Why5 the remaining issue was stale/asynchronous PR status, not a source conflict or test failure",
+      "gh issue list --state open --limit 1 --json number,title,url,createdAt,updatedAt,author,labels -> #319 Fix cleanup race with active re-downloads https://github.com/tbrandenburg/sofathek/issues/319",
+      "gh pr view 320 --json number,title,url,headRefName,baseRefName,mergeable,mergeStateStatus,statusCheckRollup -> #320 Fix: run cleanup before queue processing (#319), mergeable=MERGEABLE, mergeStateStatus=CLEAN, all six CI check runs conclusion=SUCCESS",
+      "gh api repos/tbrandenburg/sofathek/pulls/320 --jq '{number, html_url, state, draft, mergeable, mergeable_state, rebaseable, maintainer_can_modify, head: .head.ref, head_sha: .head.sha, base: .base.ref, base_sha: .base.sha, updated_at}' -> mergeable=true, mergeable_state=clean, rebaseable=true, draft=false, state=open, head_sha=d052ca7fc0028f7de6157bc7e8ca4ca79ea264d6",
+      "gh pr checks 320 -> CI Pipeline Complete pass; Level 4 E2E Tests pass; Level 1 Static Analysis pass; Level 5 Integration pass; Level 2 Build & Functional pass; Level 3 Unit Tests pass",
+      "git merge-tree $(git merge-base HEAD origin/main) HEAD origin/main -> no output, confirming no local merge conflicts"
+    ],
+    "last_verified": "2026-05-18T19:14:11Z"
   }
 }

--- a/dev/state/task-ledger.json
+++ b/dev/state/task-ledger.json
@@ -371,5 +371,29 @@
       "gh pr view 316 --json mergeable,mergeStateStatus,statusCheckRollup,url -> mergeable=MERGEABLE mergeStateStatus=CLEAN; all six CI check runs conclusion=SUCCESS"
     ],
     "last_verified": "2026-05-18T15:09:43Z"
+  },
+  "identify-latest-issue-and-linked-pr": {
+    "status": "done",
+    "evidence": [
+      "gh issue list --state open --limit 1 --json number,title,url,createdAt,updatedAt,author,labels -> #319 Fix cleanup race with active re-downloads https://github.com/tbrandenburg/sofathek/issues/319",
+      "gh pr list --state open --search \"319\" --json number,title,url,headRefName,baseRefName,mergeStateStatus,isDraft,statusCheckRollup,reviewDecision -> #320 Fix: run cleanup before queue processing (#319), mergeStateStatus=UNSTABLE"
+    ],
+    "last_verified": "2026-05-18T17:16:27Z"
+  },
+  "resolve-pr-320-merge-issue": {
+    "status": "done",
+    "evidence": [
+      "gh pr checks 320 -> Level 5: Integration pending; Static Analysis, Build & Functional, Unit Tests, E2E Tests pass",
+      "gh pr view 320 --json number,url,mergeStateStatus,mergeable,statusCheckRollup -> mergeStateStatus=CLEAN, mergeable=MERGEABLE"
+    ],
+    "last_verified": "2026-05-18T17:17:09Z"
+  },
+  "observe-pr-320-ci-until-passing": {
+    "status": "done",
+    "evidence": [
+      "gh pr checks 320 --watch -> CI Pipeline Complete pass; Level 5 Integration pass; Static Analysis pass; Build & Functional pass; Unit Tests pass; E2E Tests pass",
+      "gh pr checks 320 -> CI Pipeline Complete pass; Level 5 Integration pass; Static Analysis pass; Build & Functional pass; Unit Tests pass; E2E Tests pass"
+    ],
+    "last_verified": "2026-05-18T17:17:09Z"
   }
 }

--- a/dev/state/task-ledger.json
+++ b/dev/state/task-ledger.json
@@ -403,8 +403,8 @@
       "gh pr view 320 --json number,title,url,headRefName,baseRefName,mergeable,mergeStateStatus,statusCheckRollup -> #320 Fix: run cleanup before queue processing (#319), mergeable=MERGEABLE, mergeStateStatus=CLEAN, all six CI check runs conclusion=SUCCESS",
       "gh api repos/tbrandenburg/sofathek/pulls/320 --jq '{number, html_url, mergeable, mergeable_state, draft, state, head: .head.ref, base: .base.ref}' -> mergeable=true, mergeable_state=clean, draft=false, state=open",
       "git merge-tree $(git merge-base HEAD origin/main) HEAD origin/main -> no output, no local merge conflicts",
-      "git rev-parse --verify HEAD && git rev-parse --verify origin/fix/issue-319-cleanup-race -> both 4247b6fe7123e8fb065762dda221695d793cca57"
+      "git rev-parse --verify HEAD && git rev-parse --verify origin/fix/issue-319-cleanup-race -> both 740f3430d9f1b4ba6cb5f887744aab06fb6c6451"
     ],
-    "last_verified": "2026-05-18T18:49:01Z"
+    "last_verified": "2026-05-18T19:03:00Z"
   }
 }

--- a/dev/state/task-ledger.json
+++ b/dev/state/task-ledger.json
@@ -429,8 +429,11 @@
       "gh pr view 320 --json number,title,url,state,headRefName,baseRefName,mergeStateStatus,mergeable,statusCheckRollup -> PR #320 OPEN, mergeable MERGEABLE, mergeStateStatus CLEAN, CI checks SUCCESS",
       "gh api repos/tbrandenburg/sofathek/pulls/320 --jq '{mergeable: .mergeable, mergeable_state: .mergeable_state, rebaseable: .rebaseable, draft: .draft, state: .state, head: .head.sha, base: .base.sha}' -> mergeable=true, mergeable_state=clean, rebaseable=true, draft=false, state=open",
       "git rev-list --left-right --count origin/main...HEAD -> 0 7",
-      "git merge-tree $(git merge-base origin/main HEAD) origin/main HEAD -> merged results for changed files and no conflict markers"
+      "git merge-tree $(git merge-base origin/main HEAD) origin/main HEAD -> merged results for changed files and no conflict markers",
+      "node -e \"JSON.parse(require('fs').readFileSync('dev/state/task-ledger.json','utf8')); console.log('task-ledger.json valid')\" -> task-ledger.json valid",
+      "git push -u origin HEAD -> pre-push validation passed: linting passed, type checking passed, build validation passed",
+      "gh pr checks 320 --watch -> CI Pipeline Complete pass; Level 4 E2E Tests pass; Level 1 Static Analysis pass; Level 5 Integration pass; Level 2 Build & Functional pass; Level 3 Unit Tests pass"
     ],
-    "last_verified": "2026-05-18T21:06:23Z"
+    "last_verified": "2026-05-18T21:14:31Z"
   }
 }

--- a/dev/state/task-ledger.json
+++ b/dev/state/task-ledger.json
@@ -395,5 +395,16 @@
       "gh pr checks 320 -> CI Pipeline Complete pass; Level 5 Integration pass; Static Analysis pass; Build & Functional pass; Unit Tests pass; E2E Tests pass"
     ],
     "last_verified": "2026-05-18T17:17:09Z"
+  },
+  "resolve-pr-320-merge-issues-fresh-verification": {
+    "status": "done",
+    "evidence": [
+      "gh issue list --state open --limit 1 --json number,title,url,createdAt,updatedAt -> #319 Fix cleanup race with active re-downloads https://github.com/tbrandenburg/sofathek/issues/319",
+      "gh pr view 320 --json number,title,url,headRefName,baseRefName,mergeable,mergeStateStatus,statusCheckRollup -> #320 Fix: run cleanup before queue processing (#319), mergeable=MERGEABLE, mergeStateStatus=CLEAN, all six CI check runs conclusion=SUCCESS",
+      "gh api repos/tbrandenburg/sofathek/pulls/320 --jq '{number, html_url, mergeable, mergeable_state, draft, state, head: .head.ref, base: .base.ref}' -> mergeable=true, mergeable_state=clean, draft=false, state=open",
+      "git merge-tree $(git merge-base HEAD origin/main) HEAD origin/main -> no output, no local merge conflicts",
+      "git rev-parse --verify HEAD && git rev-parse --verify origin/fix/issue-319-cleanup-race -> both 4247b6fe7123e8fb065762dda221695d793cca57"
+    ],
+    "last_verified": "2026-05-18T18:49:01Z"
   }
 }

--- a/dev/state/task-ledger.json
+++ b/dev/state/task-ledger.json
@@ -419,5 +419,18 @@
       "git merge-tree $(git merge-base HEAD origin/main) HEAD origin/main -> no output, confirming no local merge conflicts"
     ],
     "last_verified": "2026-05-18T19:14:11Z"
+  },
+  "resolve-pr-320-merge-issues-2026-05-18T210623Z": {
+    "status": "in_progress",
+    "evidence": [
+      "Selected task after loading dev/state/task-ledger.json: resolve PR #320 merge issues for latest open issue #319",
+      "5xWhy RCA: Why1 PR was reported as having merge issues because the PR UI can lag or show stale mergeability; Why2 gh API currently reports mergeable=true and mergeable_state=clean; Why3 branch divergence is 0 behind / 7 ahead of origin/main, so the PR branch contains current base; Why4 git merge-tree reports a clean merge with no conflict markers; Why5 current blocker is not a source merge conflict or CI failure, but PR metadata/ledger churn that should be re-verified and recorded.",
+      "gh issue list --state open --limit 1 --json number,title,url,createdAt,updatedAt,author -> latest open issue #319 Fix cleanup race with active re-downloads https://github.com/tbrandenburg/sofathek/issues/319",
+      "gh pr view 320 --json number,title,url,state,headRefName,baseRefName,mergeStateStatus,mergeable,statusCheckRollup -> PR #320 OPEN, mergeable MERGEABLE, mergeStateStatus CLEAN, CI checks SUCCESS",
+      "gh api repos/tbrandenburg/sofathek/pulls/320 --jq '{mergeable: .mergeable, mergeable_state: .mergeable_state, rebaseable: .rebaseable, draft: .draft, state: .state, head: .head.sha, base: .base.sha}' -> mergeable=true, mergeable_state=clean, rebaseable=true, draft=false, state=open",
+      "git rev-list --left-right --count origin/main...HEAD -> 0 7",
+      "git merge-tree $(git merge-base origin/main HEAD) origin/main HEAD -> merged results for changed files and no conflict markers"
+    ],
+    "last_verified": "2026-05-18T21:06:23Z"
   }
 }


### PR DESCRIPTION
## Summary

Prevents stale video cleanup from racing with fresh re-downloads by ensuring library cleanup completes before queue processing can start.

## Root Cause

`DownloadQueueService.addToQueue()` started queue processing before video resource cleanup completed. For a re-download with the same generated prefix, stale sidecar metadata could cause cleanup to delete freshly downloaded files.

## Changes

| File | Change |
|------|--------|
| `backend/src/services/downloadQueueService.ts` | Await existing `VideoCleanupService.cleanupOldResources()` before starting queue processing |
| `backend/src/__tests__/unit/services/downloadQueueService.test.ts` | Added ordering coverage proving download processing does not start while cleanup is pending |

## Testing

- [x] Affected unit tests pass
- [x] Backend full Jest suite passes
- [x] Backend type check passes
- [x] Backend lint passes
- [x] Push validation passed (lint + type checking + build)

## Validation

```bash
cd backend && npx jest --testPathPattern="downloadQueueService" --no-coverage
cd backend && npx jest --no-coverage
cd backend && npx tsc --noEmit
cd backend && npm run lint
git push -u origin HEAD
```

## Issue

Fixes #319

---

<details>
<summary>Implementation Details</summary>

### Implementation followed artifact:

Investigation comment on issue #319.

### Deviations from plan:

The code had changed since investigation: `VideoCleanupService` and cleanup tests already existed, and `DownloadQueueService` already accepted a cleanup service. I reused the existing cleanup implementation and moved/awaited the existing cleanup call before queue processing instead of adding duplicate cleanup logic to `DownloadQueueService`.

No local `.ghar/issues/issue-319.md` or `.claude/PRPs/issues/issue-319.md` artifact file existed to archive.

</details>

---

_Automated implementation from investigation artifact_