### PR TITLE
Chore: ignore task-ledger.json tracking artifact

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -185,3 +185,6 @@ test_output.zip
 
 # Ghar issue management artifacts
 .ghar/
+
+# Development tracking artifacts
+task-ledger.json


### PR DESCRIPTION
## Problem

The `task-ledger.json` file is a development tracking artifact created during issue workflows. It records task status and evidence for completed work items but is not part of the source code. Having it at the repo root clutters the directory and risks accidental commits.

## Solution

Add `task-ledger.json` to `.gitignore` under a new "Development tracking artifacts" section, following the existing pattern used for `.ghar/` issue management artifacts.

## Changes

- Added `task-ledger.json` to `.gitignore`

## Testing

- `make lint` ✅
- `make build` ✅
- `git status` confirms `task-ledger.json` is now ignored

## Notes

Pre-existing integration test failures in `thumbnail-regeneration.integration.test.ts` (missing video fixture) are unrelated to this change.