### PR TITLE
Fix: Clean up .gitignore: remove duplicate entries and add missing patterns (#336)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,7 +84,6 @@ out
 dist
 
 # Gatsby files
-.cache/
 # Comment in the public line in if your project uses Gatsby and not Next.js
 # https://nextjs.org/blog/next-9-1#public-directory-support
 # public
@@ -94,7 +93,6 @@ dist
 
 # vuepress v2.x temp and cache directory
 .temp
-.cache
 
 # Sveltekit cache directory
 .svelte-kit/
@@ -167,7 +165,6 @@ coverage/
 frontend/playwright-report/
 frontend/test-results/
 backend/temp/test-queue/
-data/videos/*.mp4
 *.zip
 
 # Data
@@ -179,7 +176,6 @@ backend/data/videos/*
 temp/
 
 # Playwright test artifacts
-playwright-videos/
 test_output.zip
 .playwright-mcp/
 
@@ -188,3 +184,4 @@ test_output.zip
 
 # Development tracking artifacts
 task-ledger.json
+tmp-cw-run-*/


### PR DESCRIPTION
## Summary

The `.gitignore` file has accumulated duplicate entries from multiple framework templates and PRs: `.cache` appears 3×, `playwright-videos/` appears 2×, and `data/videos/*.mp4` is redundant with the existing `data/videos/`. Additionally, `tmp-cw-run-*/` temp workflow directories are not covered by any pattern.

## Root Cause

The `.gitignore` file grew organically via multiple template merges and PRs that added overlapping patterns without deduplication. The duplicates were accretive from the initial commit (`ca42c38`) and subsequent PRs (#22, #195, #197).

## Changes

| File | Change |
|------|--------|
| `.gitignore` | Remove duplicate `.cache/` from Gatsby section (line 87) |
| `.gitignore` | Remove duplicate `.cache` from vuepress section (line 97) |
| `.gitignore` | Remove redundant `data/videos/*.mp4` (covered by `data/videos/`) |
| `.gitignore` | Remove duplicate `playwright-videos/` from Playwright artifacts section |
| `.gitignore` | Add `tmp-cw-run-*/` pattern for CI temp directories |

## Testing

- [x] `git check-ignore -v .cache` → matches single remaining entry at line 75
- [x] `git check-ignore -v data/videos/some-file.mp4` → matches `data/` at line 171
- [x] `git check-ignore -v playwright-videos/some-video.webm` → matches single entry at line 163
- [x] `git check-ignore -v tmp-cw-run-12345/some-file` → matches new pattern at line 187

## Validation

```bash
git check-ignore -v .cache &&
git check-ignore -v data/videos/some-file.mp4 &&
git check-ignore -v playwright-videos/some-video.webm &&
git check-ignore -v tmp-cw-run-12345/some-file
```

## Issue

Fixes #336

<details>
<summary>📋 Implementation Details</summary>

### Implementation followed investigation comment:

Issue #336 investigation comment from `tbrandenburg`

### Deviations from plan:

None — all 5 steps implemented as specified.

</details>

_Automated implementation from investigation artifact_