### PR TITLE
Fix: dev/workflows.yml not tracked - gitignore excludes entire dev/ directory (#340)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,7 +150,8 @@ backend/temp/
 backend/data/temp/
 data/videos/
 .claude/
-dev/
+# Ignore generated/runtime dev artifacts, but keep source files
+dev/state/
 .worktrees/
 
 # Build artifacts


### PR DESCRIPTION
## Summary

The `.gitignore` contained a blanket `dev/` entry that silently excluded the entire `dev/` directory from version control, preventing source files like `dev/workflows.yml` from being tracked and requiring fragile `git add -f` workarounds for screenshots.

## Root Cause

`.gitignore:153` had a broad `dev/` pattern that ignored everything under `dev/`, instead of specifically ignoring only runtime artifacts.

## Changes

| File | Change |
|------|--------|
| `.gitignore:153` | Replace blanket `dev/` with fine-grained `dev/state/` pattern |

## Testing

- [x] `git check-ignore dev/workflows.yml` → empty (not ignored)
- [x] `git check-ignore dev/state/new-file.json` → ignored
- [x] `git check-ignore dev/mock-api/server.log` → still ignored
- [x] `git check-ignore dev/screenshots/new-screenshot.png` → empty (not ignored)
- [x] Existing tracked files under `dev/` unaffected

## Issue

Fixes #340

<details>
<summary>📋 Implementation Details</summary>

### Implementation followed artifact:

`.ghar/issues/issue-340.md`

### Deviations from plan:

None

</details>

_Automated implementation from investigation artifact_