### PR TITLE
fix: upgrade uuid from v9 to v11.1.1, remove @types/uuid (#353)

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -28,7 +28,7 @@
     "ffmpeggy": "^2.1.0",
     "logform": "^2.7.0",
     "readable-stream": "^3.6.2",
-    "uuid": "^9.0.1",
+    "uuid": "^11.1.1",
     "winston": "^3.17.0",
     "youtube-dl-exec": "^3.1.3",
     "zod": "^3.22.0"
@@ -40,7 +40,6 @@
     "@types/jest": "^29.5.14",
     "@types/node": "^20.17.0",
     "@types/supertest": "^2.0.16",
-    "@types/uuid": "^9.0.8",
     "@typescript-eslint/eslint-plugin": "^8.0.0",
     "@typescript-eslint/parser": "^8.0.0",
     "eslint": "^8.57.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "ffmpeggy": "^2.1.0",
         "logform": "^2.7.0",
         "readable-stream": "^3.6.2",
-        "uuid": "^9.0.1",
+        "uuid": "^11.1.1",
         "winston": "^3.17.0",
         "youtube-dl-exec": "^3.1.3",
         "zod": "^3.22.0"
@@ -47,7 +47,6 @@
         "@types/jest": "^29.5.14",
         "@types/node": "^20.17.0",
         "@types/supertest": "^2.0.16",
-        "@types/uuid": "^9.0.8",
         "@typescript-eslint/eslint-plugin": "^8.0.0",
         "@typescript-eslint/parser": "^8.0.0",
         "eslint": "^8.57.0",
@@ -3028,11 +3027,6 @@
     },
     "node_modules/@types/triple-beam": {
       "version": "1.3.5",
-      "license": "MIT"
-    },
-    "node_modules/@types/uuid": {
-      "version": "9.0.8",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/yargs": {
@@ -10187,14 +10181,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "9.0.1",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache-lib": {


### PR DESCRIPTION
## Summary

The `uuid` production dependency (pinned at `^9.0.1`) carries a moderate CVE (GHSA-w5hq-g745-h8pq) that was deferred from PR #352. This upgrades to `uuid@^11.1.1` — the minimum patched version supporting CommonJS and node@18.

## Root Cause

CVE GHSA-w5hq-g745-h8pq affects `v3()`, `v5()`, and `v6()` methods when a `buf` parameter is passed. The project uses only `v4()` without `buf`, so there is no practical exploitation risk, but `npm audit` continues to flag it. uuid@11 is the minimum version containing the patch that does not require CommonJS removal (v12+) or dropping node@18 (v14+).

## Changes

| File | Change |
|------|--------|
| `backend/package.json` | `uuid`: `^9.0.1` → `^11.1.1` |
| `backend/package.json` | Remove `@types/uuid` devDependency (v11 ships its own types) |
| `package-lock.json` | Regenerated |

No source code changes — all 7 call sites use `import { v4 as uuidv4 } from 'uuid'` which is identical across v9→v11.

## Testing

- [x] Type check passes (`tsc --noEmit`)
- [x] All 341 backend unit/integration tests pass
- [x] All 182 frontend tests pass
- [x] `npm audit` confirms GHSA-w5hq-g745-h8pq resolved

## Validation

```bash
cd backend
npm run type-check   # ✅ passes
npm test             # ✅ 341 passed, 4 skipped
npm audit            # ✅ GHSA-w5hq-g745-h8pq not listed
```

## Issue

Fixes #353

---

<details>
<summary>Implementation Details</summary>

### Implementation followed artifact:

Investigation comment on issue #353 (by GHAR, 2026-06-22T18:30:00Z)

### Deviations from plan:

None — artifact steps followed exactly. Note: issue recommended v14 but investigation correctly identified v11.1.1 as the minimum patched version compatible with the project's CJS + node@18 constraints.

</details>

---

_Automated implementation from investigation artifact_