### PR TITLE
Fix: restore task ledger history lost in PR #358 (#359)

### DIFF
--- a/dev/state/task-ledger.json
+++ b/dev/state/task-ledger.json
@@ -1,4 +1,40 @@
 {
+  "TASK_1_RCA": {
+    "status": "done",
+    "evidence": [
+      "gh issue view 348 --json number,title,body,state,url -> 'Add configurable total download size limit (default 5GB)'",
+      "grep backend/src/services/youTubeDownloadService.ts and backend/src/config.ts -> metadata.filesizeApprox exists, downloadMaxSizeBytes exists, size gate uses AppError before file download"
+    ],
+    "last_verified": "2026-06-22T16:56:53Z"
+  },
+  "TASK_2_PLAN": {
+    "status": "done",
+    "evidence": [],
+    "last_verified": "2026-06-22T16:56:53Z"
+  },
+  "TASK_3_IMPLEMENT": {
+    "status": "done",
+    "evidence": [
+      "npm test --workspace=backend -- --runInBand src/__tests__/unit/config.test.ts src/__tests__/unit/services/youTubeDownloadService.test.ts -> PASS 2/2 suites, 28/28 tests",
+      "gh pr checks 351 --watch=false -> CI Pipeline Complete pending while all component checks were already passing"
+    ],
+    "last_verified": "2026-06-22T16:56:53Z"
+  },
+  "TASK_4_COMMIT_PUSH": {
+    "status": "done",
+    "evidence": [
+      "git commit -m \"chore: record issue 348 verification\" -> 2b041a1 created",
+      "git push -> fix/issue-348-download-size-limit updated on origin"
+    ],
+    "last_verified": "2026-06-22T16:59:49Z"
+  },
+  "TASK_5_CI_ITERATE": {
+    "status": "done",
+    "evidence": [
+      "gh pr checks 351 --watch -> '✅ CI Pipeline Complete pass'; Static Analysis pass; Build & Functional pass; Unit Tests pass; E2E Tests pass; Integration pass"
+    ],
+    "last_verified": "2026-06-22T16:56:53Z"
+  },
   "issue-357": {
     "status": "done",
     "evidence": [


### PR DESCRIPTION
## Summary
Restore the five historical task-ledger records removed by PR #358 while preserving the `issue-357` verification record.

## Root Cause
PR #358 overwrote `dev/state/task-ledger.json` with only the new `issue-357` key instead of merging it with the existing ledger history.

## Changes

| File | Change |
|------|--------|
| `dev/state/task-ledger.json` | Restored `TASK_1_RCA` through `TASK_5_CI_ITERATE` and preserved `issue-357` |

## Testing

- [x] JSON validation confirms exactly six expected keys
- [x] `npm run validate:verbose` passed lint, type-check, and build
- [x] `npm test` passed 28 backend suites / 361 tests and 14 frontend files / 182 tests

## Issue

Closes #359

## Related PR

This is a follow-up to merged PR #358.