### PR TITLE
fix: default video/temp storage to ~/.local/share/sofathek/data (#370)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -176,10 +176,6 @@ backend/temp/test-queue/
 # Data
 data/
 !backend/data/
-!backend/data/videos/
-backend/data/videos/*
-!backend/data/videos/Lavar.mp4
-!backend/data/videos/Lavar-03gAoNcPO1g.mp4
 temp/
 
 # Playwright test artifacts

--- a/README.md
+++ b/README.md
@@ -157,11 +157,9 @@ sofathek/
 
 ### Development
 
-The application stores videos in `backend/data/videos` by default. Create the directory:
+The application stores videos in `~/.local/share/sofathek/data/videos` by default; this directory is auto-created on startup, so no manual setup is required.
 
-```bash
-mkdir -p backend/data/videos
-```
+If that path is a symlink pointing to unmounted external/USB storage, startup fails with a clear error (e.g. `VIDEOS_DIR storage path '...' is a broken symlink — is the external/USB drive mounted?`).
 
 To customize the video directory, set the `VIDEOS_DIR` environment variable:
 
@@ -200,9 +198,9 @@ cp backend/.env.example backend/.env
 | `SOFATHEK_BACKEND_PORT` | `3010` | Backend server port |
 | `NODE_ENV` | `development` | Runtime environment |
 | `LOG_LEVEL` | `info` | Winston logger level |
-| `VIDEOS_DIR` | `backend/data/videos` (via `cwd/data/videos`) | Path to video storage directory |
+| `VIDEOS_DIR` | `~/.local/share/sofathek/data/videos` | Path to video storage directory (auto-created; throws on startup if a broken symlink) |
 | `VIDEOS_PATH` | (fallback only) | Backward-compatible alias used only when `VIDEOS_DIR` is unset |
-| `TEMP_DIR` | `backend/data/temp` (via `cwd/data/temp`) | Path to temporary/transcoding files |
+| `TEMP_DIR` | `~/.local/share/sofathek/data/temp` | Path to temporary/transcoding files (auto-created; throws on startup if a broken symlink) |
 | `ALLOWED_ORIGINS` | `http://localhost:5183` | Comma-separated CORS allowlist for production |
 | `THUMBNAIL_MAX_SIZE` | `10485760` (10MB) | Maximum thumbnail size in bytes; larger files return HTTP 413; inaccessible thumbnail files return HTTP 403 |
 | `THUMBNAIL_CACHE_DURATION` | `86400` | Thumbnail cache max-age in seconds |

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -6,8 +6,10 @@ NODE_ENV=development
 LOG_LEVEL=info
 
 # Storage Paths
-VIDEOS_DIR=./data/videos
-TEMP_DIR=./data/temp
+# Defaults to ~/.local/share/sofathek/data/{videos,temp} when unset (auto-created on startup).
+# Note: Node does not expand `~` — if you override these, use an absolute path.
+# VIDEOS_DIR=/home/youruser/.local/share/sofathek/data/videos
+# TEMP_DIR=/home/youruser/.local/share/sofathek/data/temp
 
 # Media Processing
 FFMPEG_PATH=/usr/bin/ffmpeg

--- a/backend/src/__tests__/integration/config.test.ts
+++ b/backend/src/__tests__/integration/config.test.ts
@@ -1,4 +1,6 @@
 jest.mock('dotenv/config', () => ({}));
+import fs from 'fs';
+import os from 'os';
 import path from 'path';
 
 describe('Config', () => {
@@ -25,9 +27,10 @@ describe('Config', () => {
         loadedConfig = require('../../config').config;
       });
 
+      const expectedDataDir = path.join(os.homedir(), '.local', 'share', 'sofathek', 'data');
       expect(loadedConfig.nodeEnv).toBe('production');
-      expect(loadedConfig.videosDir).toBe(path.join(process.cwd(), 'data', 'videos'));
-      expect(loadedConfig.tempDir).toBe(path.join(process.cwd(), 'data', 'temp'));
+      expect(loadedConfig.videosDir).toBe(path.join(expectedDataDir, 'videos'));
+      expect(loadedConfig.tempDir).toBe(path.join(expectedDataDir, 'temp'));
     });
 
     it('uses fallback directories in development', () => {
@@ -41,9 +44,85 @@ describe('Config', () => {
         loadedConfig = require('../../config').config;
       });
 
+      const expectedDataDir = path.join(os.homedir(), '.local', 'share', 'sofathek', 'data');
       expect(loadedConfig.nodeEnv).toBe('development');
-      expect(loadedConfig.videosDir).toBe(path.join(process.cwd(), 'data', 'videos'));
-      expect(loadedConfig.tempDir).toBe(path.join(process.cwd(), 'data', 'temp'));
+      expect(loadedConfig.videosDir).toBe(path.join(expectedDataDir, 'videos'));
+      expect(loadedConfig.tempDir).toBe(path.join(expectedDataDir, 'temp'));
+    });
+  });
+
+  describe('directory validation with real filesystem', () => {
+    let tmpRoot: string;
+
+    beforeEach(() => {
+      tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'sofathek-config-test-'));
+    });
+
+    afterEach(() => {
+      fs.rmSync(tmpRoot, { recursive: true, force: true });
+    });
+
+    it('prefers VIDEOS_DIR/TEMP_DIR env vars over the default', () => {
+      const videos = path.join(tmpRoot, 'custom-videos');
+      const temp = path.join(tmpRoot, 'custom-temp');
+      process.env.VIDEOS_DIR = videos;
+      process.env.TEMP_DIR = temp;
+
+      let loadedConfig: any;
+      jest.isolateModules(() => {
+        loadedConfig = require('../../config').config;
+      });
+
+      expect(loadedConfig.videosDir).toBe(videos);
+      expect(loadedConfig.tempDir).toBe(temp);
+    });
+
+    it('succeeds when the configured dir is a valid symlink pointing to a real directory', () => {
+      const realDir = path.join(tmpRoot, 'real-videos');
+      const linkDir = path.join(tmpRoot, 'linked-videos');
+      fs.mkdirSync(realDir, { recursive: true });
+      fs.symlinkSync(realDir, linkDir);
+
+      process.env.VIDEOS_DIR = linkDir;
+      process.env.TEMP_DIR = path.join(tmpRoot, 'temp');
+
+      let loadedConfig: any;
+      expect(() => {
+        jest.isolateModules(() => {
+          loadedConfig = require('../../config').config;
+        });
+      }).not.toThrow();
+
+      expect(loadedConfig.videosDir).toBe(linkDir);
+    });
+
+    it('throws a clear error when the configured dir is a broken symlink', () => {
+      const missingTarget = path.join(tmpRoot, 'does-not-exist');
+      const linkDir = path.join(tmpRoot, 'broken-link');
+      fs.symlinkSync(missingTarget, linkDir);
+
+      process.env.VIDEOS_DIR = linkDir;
+      process.env.TEMP_DIR = path.join(tmpRoot, 'temp');
+
+      expect(() => {
+        jest.isolateModules(() => {
+          require('../../config');
+        });
+      }).toThrow(/broken symlink/i);
+    });
+
+    it('succeeds (no throw) when the configured dir exists but is empty', () => {
+      const emptyDir = path.join(tmpRoot, 'empty-videos');
+      fs.mkdirSync(emptyDir, { recursive: true });
+
+      process.env.VIDEOS_DIR = emptyDir;
+      process.env.TEMP_DIR = path.join(tmpRoot, 'temp');
+
+      expect(() => {
+        jest.isolateModules(() => {
+          require('../../config');
+        });
+      }).not.toThrow();
     });
   });
 });

--- a/backend/src/__tests__/integration/config.test.ts
+++ b/backend/src/__tests__/integration/config.test.ts
@@ -16,6 +16,21 @@ describe('Config', () => {
   });
 
   describe('defaults and environment handling', () => {
+    let fakeHome: string;
+    let homedirSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      // Isolate os.homedir() to a throwaway temp dir so these tests never
+      // create real directories under the developer's/CI's actual home dir.
+      fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), 'sofathek-config-home-'));
+      homedirSpy = jest.spyOn(os, 'homedir').mockReturnValue(fakeHome);
+    });
+
+    afterEach(() => {
+      homedirSpy.mockRestore();
+      fs.rmSync(fakeHome, { recursive: true, force: true });
+    });
+
     it('uses fallback directories when variables are missing in production', () => {
       process.env.NODE_ENV = 'production';
       delete process.env.VIDEOS_DIR;
@@ -27,7 +42,7 @@ describe('Config', () => {
         loadedConfig = require('../../config').config;
       });
 
-      const expectedDataDir = path.join(os.homedir(), '.local', 'share', 'sofathek', 'data');
+      const expectedDataDir = path.join(fakeHome, '.local', 'share', 'sofathek', 'data');
       expect(loadedConfig.nodeEnv).toBe('production');
       expect(loadedConfig.videosDir).toBe(path.join(expectedDataDir, 'videos'));
       expect(loadedConfig.tempDir).toBe(path.join(expectedDataDir, 'temp'));
@@ -44,7 +59,7 @@ describe('Config', () => {
         loadedConfig = require('../../config').config;
       });
 
-      const expectedDataDir = path.join(os.homedir(), '.local', 'share', 'sofathek', 'data');
+      const expectedDataDir = path.join(fakeHome, '.local', 'share', 'sofathek', 'data');
       expect(loadedConfig.nodeEnv).toBe('development');
       expect(loadedConfig.videosDir).toBe(path.join(expectedDataDir, 'videos'));
       expect(loadedConfig.tempDir).toBe(path.join(expectedDataDir, 'temp'));

--- a/backend/src/__tests__/setup.ts
+++ b/backend/src/__tests__/setup.ts
@@ -1,4 +1,16 @@
 import { jest, afterEach, afterAll } from '@jest/globals';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+// Default VIDEOS_DIR/TEMP_DIR to an isolated temp directory for the whole test
+// run unless a test explicitly overrides/deletes them. This prevents any test
+// that imports `config.ts` (directly or transitively) from ever creating real
+// directories under the developer's/CI's actual home directory
+// (~/.local/share/sofathek/data), since that is now the production default.
+const testDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sofathek-test-data-'));
+process.env.VIDEOS_DIR = process.env.VIDEOS_DIR || path.join(testDataDir, 'videos');
+process.env.TEMP_DIR = process.env.TEMP_DIR || path.join(testDataDir, 'temp');
 
 // Mock external dependencies globally
 jest.mock('fs/promises', () => ({

--- a/backend/src/__tests__/unit/config.test.ts
+++ b/backend/src/__tests__/unit/config.test.ts
@@ -1,31 +1,40 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
 describe('config', () => {
   const originalEnv = process.env;
+  let tmpRoot: string;
 
   beforeEach(() => {
     jest.resetModules();
     process.env = { ...originalEnv };
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'sofathek-unit-config-test-'));
   });
 
   afterEach(() => {
     process.env = originalEnv;
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
   });
 
   it('should use VIDEOS_DIR when set', () => {
-    process.env.VIDEOS_DIR = '/custom/videos';
+    const videosDir = path.join(tmpRoot, 'custom-videos');
+    process.env.VIDEOS_DIR = videosDir;
 
     jest.isolateModules(() => {
       const { config } = require('../../config');
-      expect(config.videosDir).toBe('/custom/videos');
+      expect(config.videosDir).toBe(videosDir);
     });
   });
 
   it('should fallback to VIDEOS_PATH when VIDEOS_DIR is not set', () => {
     delete process.env.VIDEOS_DIR;
-    process.env.VIDEOS_PATH = '/fallback/videos';
+    const videosDir = path.join(tmpRoot, 'fallback-videos');
+    process.env.VIDEOS_PATH = videosDir;
 
     jest.isolateModules(() => {
       const { config } = require('../../config');
-      expect(config.videosDir).toBe('/fallback/videos');
+      expect(config.videosDir).toBe(videosDir);
     });
   });
 

--- a/backend/src/__tests__/unit/services/videoService.test.ts
+++ b/backend/src/__tests__/unit/services/videoService.test.ts
@@ -18,7 +18,11 @@ jest.mock('fs', () => ({
     mkdir: jest.fn(),
     stat: jest.fn(),
     readFile: jest.fn()
-  }
+  },
+  // Sync APIs used by config.ts's startup directory validation
+  lstatSync: jest.fn(() => ({ isSymbolicLink: () => false })),
+  statSync: jest.fn(() => ({ isDirectory: () => true })),
+  mkdirSync: jest.fn()
 }));
 
 import { VideoService } from '../../../services/videoService';
@@ -469,50 +473,41 @@ describe('VideoService', () => {
   });
 
   describe('Path Resolution', () => {
-    const originalCwd = process.cwd;
     const originalEnv = process.env;
+    const os = require('os');
+    const defaultVideosDir = path.join(os.homedir(), '.local', 'share', 'sofathek', 'data', 'videos');
 
     beforeEach(() => {
-      process.cwd = () => '/mock/cwd';
       process.env = { ...originalEnv };
       delete process.env.VIDEOS_DIR;
     });
 
     afterEach(() => {
-      process.cwd = originalCwd;
       process.env = originalEnv;
     });
 
     it('should use default path when VIDEOS_DIR is not set', () => {
-      const service = new VideoService(
-        process.env.VIDEOS_DIR || path.join(process.cwd(), 'data', 'videos')
-      );
+      const service = new VideoService(process.env.VIDEOS_DIR || defaultVideosDir);
       const filePath = service.getVideoFilePath('test.mp4');
-      expect(filePath).toBe(path.join('/mock/cwd', 'data', 'videos', 'test.mp4'));
+      expect(filePath).toBe(path.join(defaultVideosDir, 'test.mp4'));
     });
 
     it('should use environment variable override when VIDEOS_DIR is set', () => {
       process.env.VIDEOS_DIR = '/custom/videos';
-      const service = new VideoService(
-        process.env.VIDEOS_DIR || path.join(process.cwd(), 'data', 'videos')
-      );
+      const service = new VideoService(process.env.VIDEOS_DIR || defaultVideosDir);
       const filePath = service.getVideoFilePath('test.mp4');
       expect(filePath).toBe(path.join('/custom/videos', 'test.mp4'));
     });
 
     it('should produce absolute paths', () => {
-      const service = new VideoService(
-        process.env.VIDEOS_DIR || path.join(process.cwd(), 'data', 'videos')
-      );
+      const service = new VideoService(process.env.VIDEOS_DIR || defaultVideosDir);
       const filePath = service.getVideoFilePath('test.mp4');
       expect(path.isAbsolute(filePath)).toBe(true);
     });
 
     it('should not contain dangerous path traversals in default path', () => {
       delete process.env.VIDEOS_DIR;
-      const service = new VideoService(
-        process.env.VIDEOS_DIR || path.join(process.cwd(), 'data', 'videos')
-      );
+      const service = new VideoService(process.env.VIDEOS_DIR || defaultVideosDir);
       const filePath = service.getVideoFilePath('test.mp4');
       expect(filePath).not.toContain('../');
     });

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -1,4 +1,6 @@
 import 'dotenv/config';
+import fs from 'fs';
+import os from 'os';
 import path from 'path';
 
 export interface Config {
@@ -43,6 +45,30 @@ function validateDir(dir: string, name: string): void {
   if (!dir || typeof dir !== 'string') {
     throw new Error(`Invalid ${name}: ${dir}`);
   }
+
+  let lstat: fs.Stats;
+  try {
+    lstat = fs.lstatSync(dir);
+  } catch {
+    // Path does not exist at all (and is not a symlink) - normal first-run case.
+    fs.mkdirSync(dir, { recursive: true });
+    return;
+  }
+
+  if (lstat.isSymbolicLink()) {
+    try {
+      fs.statSync(dir);
+    } catch {
+      throw new Error(
+        `${name} storage path '${dir}' is a broken symlink — is the external/USB drive mounted?`
+      );
+    }
+  }
+
+  const stat = fs.statSync(dir);
+  if (!stat.isDirectory()) {
+    throw new Error(`${name} storage path '${dir}' exists but is not a directory`);
+  }
 }
 
 function parseAllowedOrigins(value: string | undefined): string[] {
@@ -58,8 +84,10 @@ function parseAllowedOrigins(value: string | undefined): string[] {
 }
 
 function getConfig(): Config {
-  const videosDir = process.env.VIDEOS_DIR || process.env.VIDEOS_PATH || path.join(process.cwd(), 'data', 'videos');
-  const tempDir = process.env.TEMP_DIR || path.join(process.cwd(), 'data', 'temp');
+  const defaultDataDir = path.join(os.homedir(), '.local', 'share', 'sofathek', 'data');
+  const videosDir =
+    process.env.VIDEOS_DIR || process.env.VIDEOS_PATH || path.join(defaultDataDir, 'videos');
+  const tempDir = process.env.TEMP_DIR || path.join(defaultDataDir, 'temp');
 
   return {
     port: parseIntOrDefault(process.env.SOFATHEK_BACKEND_PORT, 3010),


### PR DESCRIPTION
Fixes #370

## Summary

Changes the default video/temp storage location from the repo-relative `process.cwd()/data/{videos,temp}` to a user-level, XDG-style path (`~/.local/share/sofathek/data/{videos,temp}`), keeps it fully configurable via `VIDEOS_DIR`/`TEMP_DIR` env vars (unchanged precedence), and adds startup error handling for removable/USB storage scenarios (unmounted drive, empty drive, broken symlink).

### Behavior

| Scenario | Result |
|---|---|
| No env vars set (fresh install) | Uses `~/.local/share/sofathek/data/{videos,temp}`, auto-created if missing |
| `VIDEOS_DIR`/`TEMP_DIR` set | Always takes precedence over the default (unchanged) |
| Configured dir is a valid symlink to another disk (e.g. mounted USB) | Works transparently |
| Configured dir is a **broken symlink** (target missing, e.g. USB unplugged/not mounted) | **Fails fast at startup** with a clear error: `"<NAME> storage path '<path>' is a broken symlink — is the external/USB drive mounted?"` |
| Configured dir exists but is **empty** (e.g. freshly mounted/formatted USB) | Starts normally, not treated as an error |
| Configured dir exists but is a file, not a directory | Fails fast with a clear error |

### Files changed
- `backend/src/config.ts`: new default path (`os.homedir()`-based) + real `fs.lstatSync`/`fs.statSync`-based startup validation replacing the old string-only check
- `backend/.env.example`: updated `VIDEOS_DIR`/`TEMP_DIR` example/comments
- `README.md`: updated storage setup docs
- `.gitignore`: removed dead `backend/data/videos/*.mp4` whitelist rules (default no longer lives in-repo)
- `backend/src/__tests__/integration/config.test.ts`: updated default-path assertions; added real-filesystem tests (temp dirs + real `fs.symlinkSync`, no mocking) for env-override precedence, valid symlink, broken symlink, and empty-dir scenarios; isolated the two default-path tests from the real home directory via `os.homedir()` mock to a temp dir
- `backend/src/__tests__/unit/config.test.ts`: switched hardcoded example paths to real writable temp dirs (needed since validation now really does `mkdirSync`/`statSync`)
- `backend/src/__tests__/unit/services/videoService.test.ts`: updated default-path expectations; extended existing `fs` mock with sync APIs used by config startup validation
- `backend/src/__tests__/setup.ts`: global test setup now defaults `VIDEOS_DIR`/`TEMP_DIR` to an isolated temp dir for the whole test run, so no test can accidentally create real directories under a developer's/CI's actual home directory

### Out of scope (unaffected, verified)
- `docker-compose.yml` / `backend/Dockerfile`: already set `VIDEOS_DIR=/app/data/videos`, `TEMP_DIR=/app/data/temp` explicitly — env vars always override the default, no change needed.
- No new symlink-resolution logic needed for existing path-safety boundary checks (`api.ts`, `fileValidation.ts`) — directory symlinks are already followed transparently by Node's `fs` APIs.

## Validation run

```
cd backend && npm run lint        # clean, no errors
cd backend && npx tsc --noEmit    # clean, no errors
cd backend && npm test            # Test Suites: 28 passed, 1 skipped (pre-existing) / Tests: 368 passed, 4 skipped (pre-existing)
```

## E2E coverage (real process, no mocks)

Ran the actual built server (`node dist/server.js`) on isolated ports with real filesystem state:

1. **Default path, no env vars** → server started, real dirs auto-created at `~/.local/share/sofathek/data/{videos,temp}` (verified with `ls`, then cleaned up).
2. **Broken symlink** (`VIDEOS_DIR` pointing to a symlink whose target doesn't exist, simulating an unmounted USB drive) → process exited immediately (`exit=1`) with the exact expected error: `Error: VIDEOS_DIR storage path '...' is a broken symlink — is the external/USB drive mounted?`
3. **Empty existing directory** (`VIDEOS_DIR` pointing to a real, empty dir, simulating a freshly mounted/formatted USB) → server started and stayed up (no crash), directory remained empty as expected.

All temp artifacts and real home-directory test side effects created during manual E2E testing were cleaned up afterward; the updated automated test suite no longer touches the real home directory (verified via `ls ~/.local/share/sofathek` returning "No such file or directory" after a full `npm test` run).

## Risks / follow-ups
- Mid-session USB disconnect (drive unplugged while the server is already running) is not specifically handled beyond existing error propagation in service/route layers — this was explicitly called out as out of scope in the issue (no auto-remount/reconnect logic).
- No unrelated issues discovered during this work.
