### PR TITLE
Fix: Backend crashes with ENOENT on queue save due to race condition (#372)

### DIFF
--- a/backend/src/__tests__/unit/services/queuePersistence.test.ts
+++ b/backend/src/__tests__/unit/services/queuePersistence.test.ts
@@ -1,0 +1,81 @@
+import { saveQueue } from '../../../services/queuePersistence';
+import { QueueItem } from '../../../types/youtube';
+
+const mockMkdir = jest.fn();
+const mockWriteFile = jest.fn();
+const mockRename = jest.fn();
+const mockUnlink = jest.fn();
+
+jest.mock('fs/promises', () => ({
+  mkdir: (...args: any[]) => mockMkdir(...args),
+  writeFile: (...args: any[]) => mockWriteFile(...args),
+  rename: (...args: any[]) => mockRename(...args),
+  unlink: (...args: any[]) => mockUnlink(...args)
+}));
+
+function makeQueueItem(id: string): QueueItem {
+  return {
+    id,
+    request: { url: `https://youtu.be/${id}`, requestId: id, requestedAt: new Date() },
+    status: 'pending',
+    progress: 0,
+    currentStep: 'Queued',
+    queuedAt: new Date()
+  } as QueueItem;
+}
+
+describe('saveQueue serialization', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockMkdir.mockResolvedValue(undefined);
+    mockWriteFile.mockResolvedValue(undefined);
+    mockRename.mockResolvedValue(undefined);
+    mockUnlink.mockResolvedValue(undefined);
+  });
+
+  it('should serialize concurrent saves: second write starts only after first completes', async () => {
+    let releaseFirstWrite!: () => void;
+    const firstWrite = new Promise<void>(resolve => {
+      releaseFirstWrite = resolve;
+    });
+    mockWriteFile.mockImplementationOnce(() => firstWrite);
+
+    const first = saveQueue('/tmp/q.json', [makeQueueItem('a')]);
+    const second = saveQueue('/tmp/q.json', [makeQueueItem('b')]);
+
+    await new Promise(resolve => setImmediate(resolve));
+
+    expect(mockWriteFile).toHaveBeenCalledTimes(1);
+
+    releaseFirstWrite();
+    await Promise.all([first, second]);
+    await new Promise(resolve => setImmediate(resolve));
+
+    expect(mockWriteFile).toHaveBeenCalledTimes(2);
+    expect(mockRename).toHaveBeenCalledTimes(2);
+  });
+
+  it('should use a unique temp filename per write', async () => {
+    await Promise.all([saveQueue('/tmp/q.json', [makeQueueItem('a')]), saveQueue('/tmp/q.json', [makeQueueItem('b')])]);
+    const tempArgs = mockWriteFile.mock.calls.map((call: any[]) => call[0] as string);
+    const tempFiles = tempArgs.filter(p => p.includes('.tmp'));
+    expect(new Set(tempFiles).size).toBe(2);
+  });
+
+  it('should continue persisting after a failed save (chain recovers)', async () => {
+    mockWriteFile.mockRejectedValueOnce(new Error('disk full'));
+
+    await expect(saveQueue('/tmp/q.json', [makeQueueItem('a')])).rejects.toThrow('Failed to save download queue');
+
+    await expect(saveQueue('/tmp/q.json', [makeQueueItem('b')])).resolves.toBeUndefined();
+    expect(mockRename).toHaveBeenCalledTimes(1);
+  });
+
+  it('should clean up the orphaned temp file when write/rename fails', async () => {
+    mockRename.mockRejectedValueOnce(new Error('ENOENT'));
+
+    await expect(saveQueue('/tmp/q.json', [makeQueueItem('a')])).rejects.toThrow('Failed to save download queue');
+
+    expect(mockUnlink).toHaveBeenCalledWith(expect.stringContaining('.tmp'));
+  });
+});

--- a/backend/src/__tests__/unit/services/queueScheduler.test.ts
+++ b/backend/src/__tests__/unit/services/queueScheduler.test.ts
@@ -209,5 +209,25 @@ describe('processQueueItem', () => {
       capturedCallback?.('audio', 100); // 75 + 100*0.1 = 85
       expect(item.currentStep).toBe('Downloading audio (85%)');
     });
+
+    it('should not crash or reject when a background progress save fails', async () => {
+      const item = makeQueueItem();
+      let capturedCallback: ((phase: 'video' | 'audio', percent: number) => void) | undefined;
+
+      mockDownloadVideo.mockImplementation(async (_req: unknown, _key: unknown, cb: (phase: 'video' | 'audio', percent: number) => void) => {
+        capturedCallback = cb;
+        return { status: 'success', videoPath: '/tmp/test.mp4' };
+      });
+
+      await processQueueItem(item, mockYoutubeService, mockSaveQueue);
+
+      mockSaveQueue.mockRejectedValueOnce(new Error('ENOENT: rename'));
+      capturedCallback?.('video', 10);
+
+      // Let the fire-and-forget save settle; if unhandled, jest/Node would report an unhandled rejection.
+      await new Promise(resolve => setImmediate(resolve));
+
+      expect(item.status).toBe('completed');
+    });
   });
 });

--- a/backend/src/services/queuePersistence.ts
+++ b/backend/src/services/queuePersistence.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs/promises';
 import { getErrorMessage } from '../utils/error';
 import * as path from 'path';
+import { randomUUID } from 'crypto';
 import { AppError } from '../middleware/errorHandler';
 import { QueueItem } from '../types/youtube';
 import { logger } from '../utils/logger';
@@ -54,14 +55,25 @@ export async function loadQueue(queueFilePath: string): Promise<QueueItem[]> {
   }
 }
 
-export async function saveQueue(queueFilePath: string, queue: QueueItem[]): Promise<void> {
+// Module-level async mutex chain; always kept resolved so the lock can never stay held.
+let queueSaveChain: Promise<void> = Promise.resolve();
+
+async function persistQueue(queueFilePath: string, queue: QueueItem[]): Promise<void> {
   try {
     const queueDir = path.dirname(queueFilePath);
     await fs.mkdir(queueDir, { recursive: true });
 
-    const tempFilePath = `${queueFilePath}.tmp`;
-    await fs.writeFile(tempFilePath, JSON.stringify(queue, null, 2), 'utf-8');
-    await fs.rename(tempFilePath, queueFilePath);
+    // Unique temp file per write: concurrent writers (even from a second backend
+    // process sharing data/temp) never share a path, so a rename can't hit ENOENT.
+    const tempFilePath = `${queueFilePath}.${randomUUID()}.tmp`;
+    try {
+      await fs.writeFile(tempFilePath, JSON.stringify(queue, null, 2), 'utf-8');
+      await fs.rename(tempFilePath, queueFilePath);
+    } catch (error) {
+      // Best-effort cleanup of the orphaned temp file; never mask the original error.
+      await fs.unlink(tempFilePath).catch(() => {});
+      throw error;
+    }
 
     logger.debug('Queue saved to storage', {
       queueSize: queue.length,
@@ -74,4 +86,10 @@ export async function saveQueue(queueFilePath: string, queue: QueueItem[]): Prom
     });
     throw new AppError('Failed to save download queue', 500);
   }
+}
+
+export function saveQueue(queueFilePath: string, queue: QueueItem[]): Promise<void> {
+  const result = queueSaveChain.then(() => persistQueue(queueFilePath, queue));
+  queueSaveChain = result.catch(() => {});
+  return result;
 }

--- a/backend/src/services/queueScheduler.ts
+++ b/backend/src/services/queueScheduler.ts
@@ -98,7 +98,12 @@ export async function processQueueItem(
           ? `Downloading video (${item.progress}%)`
           : `Downloading audio (${item.progress}%)`;
         lastSavedProgress = mapped;
-        saveQueue();
+        saveQueue().catch(error => {
+          logger.error('Failed to persist queue progress', {
+            queueItemId: item.id,
+            error: getErrorMessage(error)
+          });
+        });
       }
     };
 


### PR DESCRIPTION
## Summary

The backend process crashes (uncaught `AppError`, `process.exit`) when `saveQueue()` fails with `ENOENT` while renaming the queue's temp file, since multiple concurrent callers wrote to the same shared temp path and a fire-and-forget progress save had no rejection handler.

## Root Cause

Multiple call sites invoke `DownloadQueueService.saveQueue()` concurrently without serialization, and `queuePersistence.saveQueue()` always writes to the same fixed temp path (`queueFilePath + '.tmp'`). When two writers overlap, the first `rename()` succeeds and removes the temp file; the second then fails with `ENOENT`. This `AppError` propagates to the fire-and-forget progress save in `queueScheduler.ts:101` (no `await`/`.catch`), becoming an unhandled promise rejection that crashes the Node process.

## Changes

| File | Change |
|------|--------|
| `backend/src/services/queuePersistence.ts` | Serialize all `saveQueue()` calls behind an in-process promise chain and use a unique temp filename (`randomUUID()`) per write with best-effort cleanup of orphaned temp files on failure |
| `backend/src/services/queueScheduler.ts` | Attach `.catch()` to the fire-and-forget progress save so failures are logged instead of crashing the process |
| `backend/src/__tests__/unit/services/queuePersistence.test.ts` | New tests for write serialization, unique temp filenames, failure recovery, and orphaned temp cleanup |
| `backend/src/__tests__/unit/services/queueScheduler.test.ts` | Added regression test: a failed background progress save no longer crashes/rejects |

## Testing

- [x] Type check passes
- [x] Unit tests pass (full backend + frontend suite: 373 backend + 182 frontend passed)
- [x] Lint passes

## Validation

```bash
cd backend && npm run type-check
cd backend && npx jest src/__tests__/unit/services/queuePersistence.test.ts src/__tests__/unit/services/queueScheduler.test.ts src/__tests__/unit/services/downloadQueueService.test.ts
cd backend && npm run lint
```

## Issue

Fixes #372

---

<details>
<summary>📋 Implementation Details</summary>

### Implementation followed the GitHub Actions investigation comment on issue #372 exactly.

### Deviations from plan:

None.

</details>

---

_Automated implementation from investigation artifact_