### PR TITLE
Fix: bound nanoid override to Node 18-compatible 3.x (#376)

### DIFF
--- a/dev/state/task-ledger.json
+++ b/dev/state/task-ledger.json
@@ -96,5 +96,18 @@
       "gh pr view 378 --json mergeStateStatus,mergeable -> mergeStateStatus CLEAN, mergeable MERGEABLE"
     ],
     "last_verified": "2026-08-14T08:30:30Z"
+  },
+  "issue-376-pr-379": {
+    "status": "done",
+    "evidence": [
+      "gh issue list --state open --limit 100 --json number,title,createdAt,url: latest open issue is #376, Constrain nanoid override to the Node 18-compatible 3.x line",
+      "gh pr view 379 --json number,title,url,mergeStateStatus,mergeable: linked PR #379 is MERGEABLE with mergeStateStatus CLEAN",
+      "gh pr checks 379 --watch=false: CI Pipeline Complete, Static Analysis, Build & Functional, Unit Tests, E2E Tests, and Integration all pass",
+      "npm ls nanoid --all: only nanoid@3.3.18 resolves; npm view nanoid@6.0.1 engines: Node ^22 || ^24 || >=26",
+      "npm audit --audit-level=high in root and frontend: found 0 vulnerabilities",
+      "make lint; make type-check; make build: all passed",
+      "npm test: backend 29 passed suites with 373 passed tests and frontend 14 passed files with 182 passed tests"
+    ],
+    "last_verified": "2026-08-14T10:15:21Z"
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,7 +17,7 @@
     "test:e2e": "playwright test"
   },
   "overrides": {
-    "nanoid": ">=3.3.18"
+    "nanoid": ">=3.3.18 <4.0.0"
   },
   "dependencies": {
     "@radix-ui/react-dropdown-menu": "^2.1.16",

--- a/package.json
+++ b/package.json
@@ -74,6 +74,6 @@
     "handlebars": ">=4.7.9",
     "path-to-regexp": "0.1.13",
     "brace-expansion": ">=5.0.9",
-    "nanoid": ">=3.3.18"
+    "nanoid": ">=3.3.18 <4.0.0"
   }
 }


### PR DESCRIPTION
## Summary

Bound both nanoid overrides to the Node 18-compatible 3.x line while retaining the patched `>=3.3.18` floor.

## Root Cause

The existing `>=3.3.18` override had no upper bound, allowing a future lockfile regeneration to resolve nanoid 6.x, whose engine requirement excludes Node 18.

## Changes

| File | Change |
|------|--------|
| `package.json` | Changed the root nanoid override to `>=3.3.18 <4.0.0` |
| `frontend/package.json` | Changed the frontend nanoid override to `>=3.3.18 <4.0.0` |

## Testing

- [x] `npm ls nanoid --all` resolves `nanoid@3.3.18`
- [x] Root `npm audit` reports 0 vulnerabilities
- [x] Frontend `npm audit` reports 0 vulnerabilities
- [x] `make lint`
- [x] `make type-check`
- [x] `make build`
- [x] `make test`
- [x] `npm run validate:fast`

## Issue

Fixes #376

## Implementation Notes

The investigation plan referenced `frontend/pnpm-lock.yaml`, but that file was removed by the already-merged issue #377. `npm install` caused no retained lockfile changes.